### PR TITLE
Use inferred cast in SetWindowLongPtrA call for 32-bit compatibility

### DIFF
--- a/src/hook.rs
+++ b/src/hook.rs
@@ -97,7 +97,7 @@ impl DxgiHook {
       std::mem::transmute(SetWindowLongPtrA(
         sd.OutputWindow,
         GWLP_WNDPROC,
-        wnd_proc as WndProc as isize,
+        wnd_proc as _,
       ))
     };
 


### PR DESCRIPTION
Addresses #1. Fix inspired by https://github.com/linebender/druid/pull/1563