### PR TITLE
DLL eject methods for DX11 and DX12

### DIFF
--- a/hudhook/src/hooks/dx11.rs
+++ b/hudhook/src/hooks/dx11.rs
@@ -473,21 +473,3 @@ impl Hooks for ImguiDX11Hooks {
     }
 }
 
-// unsafe fn hook_imgui<T: 'static>(t: T) -> RawDetour
-// where
-//     T: ImguiRenderLoop + Send + Sync,
-// {
-//     let dxgi_swap_chain_present_addr = get_present_addr();
-//     debug!("IDXGISwapChain::Present = {:p}", dxgi_swap_chain_present_addr as *mut c_void);
-// 
-//     let hook = RawDetour::new(
-//         dxgi_swap_chain_present_addr as *const _,
-//         imgui_dxgi_swap_chain_present_impl as *const _,
-//     )
-//     .expect("Create detour");
-// 
-//     IMGUI_RENDER_LOOP.get_or_init(|| Box::new(t));
-//     TRAMPOLINE.get_or_init(|| std::mem::transmute(hook.trampoline()));
-// 
-//     hook
-// }

--- a/hudhook/src/hooks/dx11.rs
+++ b/hudhook/src/hooks/dx11.rs
@@ -2,7 +2,8 @@ use std::ffi::c_void;
 use std::ptr::{null, null_mut};
 
 use detour::RawDetour;
-use imgui::Key;
+use imgui::{Key, Ui};
+use imgui_dx11::RenderEngine;
 use log::*;
 use once_cell::sync::OnceCell;
 use parking_lot::Mutex;
@@ -24,7 +25,7 @@ use windows::Win32::System::LibraryLoader::GetModuleHandleA;
 use windows::Win32::UI::Input::KeyboardAndMouse::*;
 use windows::Win32::UI::WindowsAndMessaging::*;
 
-use super::{get_wheel_delta_wparam, get_xbutton_wparam, loword};
+use super::{get_wheel_delta_wparam, get_xbutton_wparam, loword, Hooks};
 
 type DXGISwapChainPresentType =
     unsafe extern "system" fn(This: IDXGISwapChain, SyncInterval: u32, Flags: u32) -> HRESULT;
@@ -43,7 +44,7 @@ trait Renderer {
 
 /// Implement your `imgui` rendering logic via this trait.
 pub trait ImguiRenderLoop {
-    fn render(&mut self, ui: &mut imgui_dx11::imgui::Ui, flags: &ImguiRenderLoopFlags);
+    fn render(&mut self, ui: &mut Ui, flags: &ImguiRenderLoopFlags);
     fn into_hook(self) -> Vec<RawDetour>
     where
         Self: Send + Sync + Sized + 'static,
@@ -63,7 +64,7 @@ static TRAMPOLINE: OnceCell<DXGISwapChainPresentType> = OnceCell::new();
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 static mut IMGUI_RENDER_LOOP: OnceCell<Box<dyn ImguiRenderLoop + Send + Sync>> = OnceCell::new();
-static IMGUI_RENDERER: OnceCell<Mutex<Box<ImguiRenderer>>> = OnceCell::new();
+static mut IMGUI_RENDERER: OnceCell<Mutex<Box<ImguiRenderer>>> = OnceCell::new();
 
 unsafe extern "system" fn imgui_dxgi_swap_chain_present_impl(
     p_this: IDXGISwapChain,
@@ -73,91 +74,10 @@ unsafe extern "system" fn imgui_dxgi_swap_chain_present_impl(
     let trampoline = TRAMPOLINE.get().expect("IDXGISwapChain::Present trampoline uninitialized");
 
     let mut renderer = IMGUI_RENDERER
-        .get_or_init(|| {
-            trace!("Initializing renderer");
-
-            let dev: ID3D11Device = p_this.GetDevice().expect("GetDevice");
-            let mut dev_ctx: Option<ID3D11DeviceContext> = None;
-            dev.GetImmediateContext(&mut dev_ctx);
-            let dev_ctx = dev_ctx.unwrap();
-            let sd = p_this.GetDesc().expect("GetDesc");
-
-            let mut engine = imgui_dx11::RenderEngine::new_with_ptrs(dev, dev_ctx, p_this.clone());
-            let render_loop = IMGUI_RENDER_LOOP.take().unwrap();
-            let wnd_proc = std::mem::transmute::<_, WndProcType>(SetWindowLongPtrA(
-                sd.OutputWindow,
-                GWLP_WNDPROC,
-                imgui_wnd_proc as usize as isize,
-            ));
-
-            trace!("Initializing imgui context");
-            let imgui_ctx = engine.ctx();
-            imgui_ctx.set_ini_filename(None);
-            let mut io = imgui_ctx.io_mut();
-            io.nav_active = true;
-            io.nav_visible = true;
-
-            // Initialize keys
-            io[Key::Tab] = VK_TAB.0 as _;
-            io[Key::LeftArrow] = VK_LEFT.0 as _;
-            io[Key::RightArrow] = VK_RIGHT.0 as _;
-            io[Key::UpArrow] = VK_UP.0 as _;
-            io[Key::DownArrow] = VK_DOWN.0 as _;
-            io[Key::PageUp] = VK_PRIOR.0 as _;
-            io[Key::PageDown] = VK_NEXT.0 as _;
-            io[Key::Home] = VK_HOME.0 as _;
-            io[Key::End] = VK_END.0 as _;
-            io[Key::Insert] = VK_INSERT.0 as _;
-            io[Key::Delete] = VK_DELETE.0 as _;
-            io[Key::Backspace] = VK_BACK.0 as _;
-            io[Key::Space] = VK_SPACE.0 as _;
-            io[Key::Enter] = VK_RETURN.0 as _;
-            io[Key::Escape] = VK_ESCAPE.0 as _;
-            io[Key::A] = VK_A.0 as _;
-            io[Key::C] = VK_C.0 as _;
-            io[Key::V] = VK_V.0 as _;
-            io[Key::X] = VK_X.0 as _;
-            io[Key::Y] = VK_Y.0 as _;
-            io[Key::Z] = VK_Z.0 as _;
-
-            let flags = ImguiRenderLoopFlags { focused: true };
-
-            trace!("Renderer initialized");
-
-            Mutex::new(Box::new(ImguiRenderer { engine, render_loop, wnd_proc, flags }))
-        })
+        .get_or_init(|| Mutex::new(Box::new(ImguiRenderer::new(p_this.clone()))))
         .lock();
 
-    {
-        trace!("Present impl: Rendering");
-        let ctx = (*renderer).ctx();
-        let sd = p_this.GetDesc().expect("GetDesc");
-        let mut rect: RECT = Default::default();
-
-        if GetWindowRect(sd.OutputWindow, &mut rect as _).as_bool() {
-            let mut io = ctx.io_mut();
-
-            io.display_size = [(rect.right - rect.left) as f32, (rect.bottom - rect.top) as f32];
-
-            let mut pos = POINT { x: 0, y: 0 };
-
-            let active_window = GetForegroundWindow();
-            if !active_window.is_invalid()
-                && (active_window == sd.OutputWindow
-                    || IsChild(active_window, sd.OutputWindow).as_bool())
-            {
-                let gcp = GetCursorPos(&mut pos as *mut _);
-                if gcp.as_bool() && ScreenToClient(sd.OutputWindow, &mut pos as *mut _).as_bool() {
-                    io.mouse_pos[0] = pos.x as _;
-                    io.mouse_pos[1] = pos.y as _;
-                }
-            }
-        } else {
-            trace!("GetWindowRect error: {:x}", GetLastError().0);
-        }
-    }
-
-    (*renderer).render();
+    renderer.render(Some(p_this.clone()));
     drop(renderer);
 
     trace!("Invoking IDXGISwapChain::Present trampoline");
@@ -273,17 +193,114 @@ unsafe extern "system" fn imgui_wnd_proc(
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 struct ImguiRenderer {
-    engine: imgui_dx11::RenderEngine,
+    engine: RenderEngine,
     render_loop: Box<dyn ImguiRenderLoop>,
     wnd_proc: WndProcType,
     flags: ImguiRenderLoopFlags,
+    swap_chain: IDXGISwapChain,
 }
 
 impl ImguiRenderer {
-    fn render(&mut self) {
+    unsafe fn new(swap_chain: IDXGISwapChain) -> Self {
+        trace!("Initializing renderer");
+
+        let dev: ID3D11Device = swap_chain.GetDevice().expect("GetDevice");
+        let mut dev_ctx: Option<ID3D11DeviceContext> = None;
+        dev.GetImmediateContext(&mut dev_ctx);
+        let dev_ctx = dev_ctx.unwrap();
+        let sd = swap_chain.GetDesc().expect("GetDesc");
+
+        let mut engine = RenderEngine::new_with_ptrs(dev, dev_ctx, swap_chain.clone());
+        let render_loop = IMGUI_RENDER_LOOP.take().unwrap();
+        let wnd_proc = std::mem::transmute::<_, WndProcType>(SetWindowLongPtrA(
+            sd.OutputWindow,
+            GWLP_WNDPROC,
+            imgui_wnd_proc as usize as isize,
+        ));
+
+        trace!("Initializing imgui context");
+        let imgui_ctx = engine.ctx();
+        imgui_ctx.set_ini_filename(None);
+        let mut io = imgui_ctx.io_mut();
+        io.nav_active = true;
+        io.nav_visible = true;
+
+        // Initialize keys
+        io[Key::Tab] = VK_TAB.0 as _;
+        io[Key::LeftArrow] = VK_LEFT.0 as _;
+        io[Key::RightArrow] = VK_RIGHT.0 as _;
+        io[Key::UpArrow] = VK_UP.0 as _;
+        io[Key::DownArrow] = VK_DOWN.0 as _;
+        io[Key::PageUp] = VK_PRIOR.0 as _;
+        io[Key::PageDown] = VK_NEXT.0 as _;
+        io[Key::Home] = VK_HOME.0 as _;
+        io[Key::End] = VK_END.0 as _;
+        io[Key::Insert] = VK_INSERT.0 as _;
+        io[Key::Delete] = VK_DELETE.0 as _;
+        io[Key::Backspace] = VK_BACK.0 as _;
+        io[Key::Space] = VK_SPACE.0 as _;
+        io[Key::Enter] = VK_RETURN.0 as _;
+        io[Key::Escape] = VK_ESCAPE.0 as _;
+        io[Key::A] = VK_A.0 as _;
+        io[Key::C] = VK_C.0 as _;
+        io[Key::V] = VK_V.0 as _;
+        io[Key::X] = VK_X.0 as _;
+        io[Key::Y] = VK_Y.0 as _;
+        io[Key::Z] = VK_Z.0 as _;
+
+        let flags = ImguiRenderLoopFlags { focused: true };
+
+        trace!("Renderer initialized");
+        ImguiRenderer { engine, render_loop, wnd_proc, flags, swap_chain }
+    }
+
+    unsafe fn render(&mut self, swap_chain: Option<IDXGISwapChain>) {
+        trace!("Present impl: Rendering");
+
+        let swap_chain = self.store_swap_chain(swap_chain);
+        let ctx = self.ctx();
+        let sd = swap_chain.GetDesc().expect("GetDesc");
+        let mut rect: RECT = Default::default();
+
+        if GetWindowRect(sd.OutputWindow, &mut rect as _).as_bool() {
+            let mut io = ctx.io_mut();
+
+            io.display_size = [(rect.right - rect.left) as f32, (rect.bottom - rect.top) as f32];
+
+            let mut pos = POINT { x: 0, y: 0 };
+
+            let active_window = GetForegroundWindow();
+            if !active_window.is_invalid()
+                && (active_window == sd.OutputWindow
+                    || IsChild(active_window, sd.OutputWindow).as_bool())
+            {
+                let gcp = GetCursorPos(&mut pos as *mut _);
+                if gcp.as_bool() && ScreenToClient(sd.OutputWindow, &mut pos as *mut _).as_bool() {
+                    io.mouse_pos[0] = pos.x as _;
+                    io.mouse_pos[1] = pos.y as _;
+                }
+            }
+        } else {
+            trace!("GetWindowRect error: {:x}", GetLastError().0);
+        }
+
         if let Err(e) = self.engine.render(|ui| self.render_loop.render(ui, &self.flags)) {
             error!("ImGui renderer error: {:?}", e);
         }
+    }
+
+    fn store_swap_chain(&mut self, swap_chain: Option<IDXGISwapChain>) -> IDXGISwapChain {
+        if let Some(swap_chain) = swap_chain {
+            self.swap_chain = swap_chain;
+        }
+
+        self.swap_chain.clone()
+    }
+
+    unsafe fn cleanup(&mut self, swap_chain: Option<IDXGISwapChain>) {
+        let swap_chain = self.store_swap_chain(swap_chain);
+        let desc = swap_chain.GetDesc().unwrap();
+        SetWindowLongPtrA(desc.OutputWindow, GWLP_WNDPROC, self.wnd_proc as usize as isize);
     }
 
     fn ctx(&mut self) -> &mut imgui_dx11::imgui::Context {
@@ -397,13 +414,64 @@ fn get_present_addr() -> DXGISwapChainPresentType {
     unsafe { std::mem::transmute(ret) }
 }
 
-/// Construct a `RawDetour` that will render UI via the provided
+pub struct ImguiDX11Hooks {
+    hook_present: RawDetour,
+}
+
+impl ImguiDX11Hooks {
+    pub unsafe fn new<T: 'static>(t: T) -> Self
+    where
+        T: ImguiRenderLoop + Send + Sync,
+    {
+        let dxgi_swap_chain_present_addr = get_present_addr();
+        debug!("IDXGISwapChain::Present = {:p}", dxgi_swap_chain_present_addr as *mut c_void);
+
+        let hook_present = RawDetour::new(
+            dxgi_swap_chain_present_addr as *const _,
+            imgui_dxgi_swap_chain_present_impl as *const _,
+        )
+        .expect("Create detour");
+
+        IMGUI_RENDER_LOOP.get_or_init(|| Box::new(t));
+        TRAMPOLINE.get_or_init(|| std::mem::transmute(hook_present.trampoline()));
+
+        Self { hook_present }
+    }
+}
+
+impl Hooks for ImguiDX11Hooks {
+    unsafe fn hook(&self) {
+        for hook in [&self.hook_present] {
+            if let Err(e) = hook.enable() {
+                error!("Couldn't enable hook: {e}");
+            }
+        }
+    }
+
+    unsafe fn unhook(&mut self) {
+        trace!("Disabling hooks...");
+        for hook in [&self.hook_present] {
+            if let Err(e) = hook.disable() {
+                error!("Couldn't disable hook: {e}");
+            }
+        }
+
+        trace!("Cleaning up renderer...");
+        if let Some(renderer) = IMGUI_RENDERER.take() {
+            renderer.lock().cleanup(None);
+        }
+
+        drop(IMGUI_RENDER_LOOP.take());
+    }
+}
+
+/// Construct a [`RawDetour` that will render UI via the provided
 /// `ImguiRenderLoop`.
 ///
 /// # Safety
 ///
 /// yolo
-pub unsafe fn hook_imgui<T: 'static>(t: T) -> RawDetour
+unsafe fn hook_imgui<T: 'static>(t: T) -> RawDetour
 where
     T: ImguiRenderLoop + Send + Sync,
 {

--- a/hudhook/src/hooks/dx12.rs
+++ b/hudhook/src/hooks/dx12.rs
@@ -669,6 +669,7 @@ pub fn disable_dxgi_debug() {
     DXGI_DEBUG_ENABLED.store(false, Ordering::SeqCst);
 }
 
+/// Stores hook detours and implements the [`Hooks`] trait.
 pub struct ImguiDX12Hooks {
     hook_dscp: RawDetour,
     hook_cqecl: RawDetour,
@@ -715,8 +716,8 @@ impl Hooks for ImguiDX12Hooks {
     }
 }
 
-/// Construct a `mh::Hook` that will render UI via the provided
-/// `ImguiRenderLoop`.
+/// Construct a set of [`RawDetour`]s that will render UI via the provided
+/// [`ImguiRenderLoop`].
 ///
 /// # Safety
 ///

--- a/hudhook/src/hooks/dx12.rs
+++ b/hudhook/src/hooks/dx12.rs
@@ -21,7 +21,7 @@ use windows::Win32::System::LibraryLoader::GetModuleHandleA;
 use windows::Win32::UI::Input::KeyboardAndMouse::*;
 use windows::Win32::UI::WindowsAndMessaging::*;
 
-use super::{get_wheel_delta_wparam, hiword, loword};
+use super::{get_wheel_delta_wparam, hiword, loword, Hooks};
 
 type DXGISwapChainPresentType =
     unsafe extern "system" fn(This: IDXGISwapChain3, SyncInterval: u32, Flags: u32) -> HRESULT;
@@ -57,11 +57,11 @@ trait Renderer {
 pub trait ImguiRenderLoop {
     fn render(&mut self, ui: &mut imgui_dx12::imgui::Ui, flags: &ImguiRenderLoopFlags);
     fn initialize(&mut self, _ctx: &mut imgui_dx12::imgui::Context) {}
-    fn into_hook(self) -> Vec<RawDetour>
+    fn into_hook(self) -> Box<dyn Hooks>
     where
         Self: Send + Sync + Sized + 'static,
     {
-        unsafe { hook_imgui(self) }
+        Box::new(ImguiDX12Hooks::new(self))
     }
 }
 
@@ -153,7 +153,7 @@ unsafe extern "system" fn imgui_resize_buffers_impl(
         TRAMPOLINE.get().expect("IDXGISwapChain3::ResizeBuffer trampoline uninitialized");
 
     if let Some(mutex) = IMGUI_RENDERER.take() {
-        mutex.lock().cleanup(swap_chain.clone());
+        mutex.lock().cleanup(Some(swap_chain.clone()));
     };
 
     COMMAND_QUEUE_GUARD.take();
@@ -175,7 +175,7 @@ unsafe extern "system" fn imgui_dxgi_swap_chain_present_impl(
         IMGUI_RENDERER.get_or_init(|| Mutex::new(Box::new(ImguiRenderer::new(swap_chain.clone()))));
 
     {
-        renderer.lock().render(swap_chain.clone());
+        renderer.lock().render(Some(swap_chain.clone()));
     }
 
     trace!("Invoking IDXGISwapChain3::Present trampoline");
@@ -294,6 +294,7 @@ struct ImguiRenderer {
     renderer_heap: ID3D12DescriptorHeap,
     command_queue: Option<ID3D12CommandQueue>,
     command_list: ID3D12GraphicsCommandList,
+    swap_chain: IDXGISwapChain3,
 }
 
 impl ImguiRenderer {
@@ -415,10 +416,21 @@ impl ImguiRenderer {
             _rtv_heap: rtv_heap,
             renderer_heap,
             frame_contexts,
+            swap_chain,
         }
     }
 
-    fn render(&mut self, swap_chain: IDXGISwapChain3) -> Option<()> {
+    fn store_swap_chain(&mut self, swap_chain: Option<IDXGISwapChain3>) -> IDXGISwapChain3 {
+        if let Some(swap_chain) = swap_chain {
+            self.swap_chain = swap_chain;
+        }
+
+        self.swap_chain.clone()
+    }
+
+    fn render(&mut self, swap_chain: Option<IDXGISwapChain3>) -> Option<()> {
+        let swap_chain = self.store_swap_chain(swap_chain);
+
         trace!("Rendering started");
         let sd = unsafe { swap_chain.GetDesc() }.unwrap();
         let mut rect: RECT = Default::default();
@@ -520,7 +532,8 @@ impl ImguiRenderer {
         None
     }
 
-    unsafe fn cleanup(&mut self, swap_chain: IDXGISwapChain3) {
+    unsafe fn cleanup(&mut self, swap_chain: Option<IDXGISwapChain3>) {
+        let swap_chain = self.store_swap_chain(swap_chain);
         let desc = swap_chain.GetDesc().unwrap();
         SetWindowLongPtrA(desc.OutputWindow, GWLP_WNDPROC, self.wnd_proc as usize as isize);
     }
@@ -608,11 +621,6 @@ fn get_present_addr() -> (DXGISwapChainPresentType, ExecuteCommandListsType, Res
 
     let command_queue: ID3D12CommandQueue =
         unsafe { dev.CreateCommandQueue(&queue_desc as *const _) }.unwrap();
-    // let command_alloc: ID3D12CommandAllocator =
-    //     unsafe { dev.CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT)
-    // }.unwrap(); let command_list: ID3D12CommandList =
-    //     unsafe { dev.CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT,
-    // &command_alloc, None) }         .unwrap();
 
     let swap_chain_desc = DXGI_SWAP_CHAIN_DESC {
         BufferDesc: DXGI_MODE_DESC {
@@ -661,13 +669,59 @@ pub fn disable_dxgi_debug() {
     DXGI_DEBUG_ENABLED.store(false, Ordering::SeqCst);
 }
 
+pub struct ImguiDX12Hooks {
+    hook_dscp: RawDetour,
+    hook_cqecl: RawDetour,
+    hook_rbuf: RawDetour,
+}
+
+impl ImguiDX12Hooks {
+    pub fn new<T: 'static>(t: T) -> Self
+    where
+        T: ImguiRenderLoop + Send + Sync,
+    {
+        let (hook_dscp, hook_cqecl, hook_rbuf) = unsafe { hook_imgui(t) };
+
+        Self { hook_dscp, hook_cqecl, hook_rbuf }
+    }
+}
+
+impl Hooks for ImguiDX12Hooks {
+    unsafe fn hook(&self) {
+        for hook in [&self.hook_dscp, &self.hook_cqecl, &self.hook_rbuf] {
+            if let Err(e) = hook.enable() {
+                error!("Couldn't enable hook: {e}");
+            }
+        }
+    }
+
+    unsafe fn unhook(&mut self) {
+        trace!("Disabling hooks...");
+        for hook in [&self.hook_dscp, &self.hook_cqecl, &self.hook_rbuf] {
+            if let Err(e) = hook.disable() {
+                error!("Couldn't disable hook: {e}");
+            }
+        }
+
+        trace!("Cleaning up renderer...");
+        if let Some(renderer) = IMGUI_RENDERER.take() {
+            renderer.lock().cleanup(None);
+        }
+
+        drop(IMGUI_RENDER_LOOP.take());
+        drop(COMMAND_QUEUE_GUARD.take());
+
+        DXGI_DEBUG_ENABLED.store(false, Ordering::SeqCst);
+    }
+}
+
 /// Construct a `mh::Hook` that will render UI via the provided
 /// `ImguiRenderLoop`.
 ///
 /// # Safety
 ///
 /// yolo
-pub unsafe fn hook_imgui<T: 'static>(t: T) -> Vec<RawDetour>
+unsafe fn hook_imgui<T: 'static>(t: T) -> (RawDetour, RawDetour, RawDetour)
 where
     T: ImguiRenderLoop + Send + Sync,
 {
@@ -705,5 +759,5 @@ where
         )
     });
 
-    vec![hook_dscp, hook_cqecl, hook_rbuf]
+    (hook_dscp, hook_cqecl, hook_rbuf)
 }

--- a/hudhook/src/hooks/mod.rs
+++ b/hudhook/src/hooks/mod.rs
@@ -1,26 +1,37 @@
+//! Implementation of platform-specific hooks.
+//!
+//! Currently DirectX 11 and DirectX 12 hooks with [`imgui`] renderers are
+//! available.
+//!
+//! [`imgui`]: https://docs.rs/imgui/0.8.0/imgui/
+
 pub mod dx11;
 pub mod dx12;
 
+/// Generic trait for platform-specific hooks.
 pub trait Hooks {
+    /// Find the hook target functions addresses, initialize the data, create
+    /// and enable the hooks.
     unsafe fn hook(&self);
+    /// Cleanup global data and disable the hooks.
     unsafe fn unhook(&mut self);
 }
 
 #[inline]
-pub fn loword(l: u32) -> u16 {
+fn loword(l: u32) -> u16 {
     (l & 0xffff) as u16
 }
 #[inline]
-pub fn hiword(l: u32) -> u16 {
+fn hiword(l: u32) -> u16 {
     ((l >> 16) & 0xffff) as u16
 }
 
 #[inline]
-pub fn get_wheel_delta_wparam(wparam: u32) -> u16 {
+fn get_wheel_delta_wparam(wparam: u32) -> u16 {
     hiword(wparam) as u16
 }
 
 #[inline]
-pub fn get_xbutton_wparam(wparam: u32) -> u16 {
+fn get_xbutton_wparam(wparam: u32) -> u16 {
     hiword(wparam)
 }

--- a/hudhook/src/hooks/mod.rs
+++ b/hudhook/src/hooks/mod.rs
@@ -1,6 +1,11 @@
 pub mod dx11;
 pub mod dx12;
 
+pub trait Hooks {
+    unsafe fn hook(&self);
+    unsafe fn unhook(&mut self);
+}
+
 #[inline]
 pub fn loword(l: u32) -> u16 {
     (l & 0xffff) as u16

--- a/hudhook/src/inject.rs
+++ b/hudhook/src/inject.rs
@@ -1,3 +1,5 @@
+//! Facilities for injecting compiled DLLs into target processes.
+
 use std::ffi::CString;
 use std::mem::size_of;
 use std::path::PathBuf;

--- a/hudhook/src/lib.rs
+++ b/hudhook/src/lib.rs
@@ -1,30 +1,40 @@
 #![feature(once_cell)]
 //! # hudhook
 //!
-//! This library implements a mechanism for hooking into the render loop of
-//! DirectX11 applications, perform memory manipulation and draw things on
-//! screen via [`imgui`](https://docs.rs/imgui/0.4.0/imgui/). It has been
-//! largely inspired by [CheatEngine](https://www.cheatengine.org/).
+//! This library implements a mechanism for hooking into the
+//! render loop of applications and drawing things on screen via
+//! [`imgui`](https://docs.rs/imgui/0.8.0/imgui/). It has been largely inspired
+//! by [CheatEngine](https://www.cheatengine.org/).
 //!
-//! It's been extracted out of the [`darksoulsiii-practice-tool`](https://github.com/veeenu/darksoulsiii-practice-tool)
-//! for generalized usage as a stand-alone framework. It is also a complete,
-//! fully-fledged example of usage; it is a good idea to refer to that for
-//! any doubts about the API which aren't clarified by this documentation.
+//! Currently, DirectX 11 and DirectX 12 are supported.
 //!
-//! Refer to [this post](https://veeenu.github.io/blog/sekiro-practice-tool-architecture/)
-//! for in-depth information about the architecture of the library.
+//! For complete, fully fledged examples of usage, check out the following
+//! projects:
+//!
+//! - [`darksoulsiii-practice-tool`](https://github.com/veeenu/darksoulsiii-practice-tool)
+//! - [`eldenring-practice-tool`](https://github.com/veeenu/eldenring-practice-tool)
+//!
+//! It is a good idea to refer to these projects for any doubts about the API
+//! which aren't clarified by this documentation, as this project is directly
+//! derived from them.
+//!
+//! Refer to [this post](https://veeenu.github.io/blog/sekiro-practice-tool-architecture/) for
+//! in-depth information about the architecture of the library.
+//!
+//! [`darksoulsiii-practice-tool`]: https://github.com/veeenu/darksoulsiii-practice-tool
+//! [`eldenring-practice-tool`]: https://github.com/veeenu/eldenring-practice-tool
 //!
 //! ## Fair warning
 //!
-//! `hudhook` provides essential, crash-safe features for memory manipulation
-//! and UI rendering. It does, alas, contain a hefty amount of FFI and `unsafe`
-//! code which still has to be thoroughly tested, validated and audited for
-//! soundness. It should be OK for small projects such as videogame mods, but
-//! it may crash your application at this stage.
+//! [`hudhook`](crate) provides essential, crash-safe features for memory
+//! manipulation and UI rendering. It does, alas, contain a hefty amount of FFI
+//! and `unsafe` code which still has to be thoroughly tested, validated and
+//! audited for soundness. It should be OK for small projects such as videogame
+//! mods, but it may crash your application at this stage.
 //!
 //! ## Examples
 //!
-//! ### Hooking the render loop and drawing things with `imgui`:
+//! ### Hooking the render loop and drawing things with `imgui`
 //!
 //! Compile your crate with both a `cdylib` and an executable target. The
 //! executable will be very minimal and used to inject the DLL into the
@@ -32,16 +42,20 @@
 //!
 //! #### Building the render loop
 //!
-//! Implement the [`RenderLoop`] trait
+//! Implement the render loop trait for your hook target.
+//!
+//! ##### Example: DirectX 11
+//!
+//! Implement the [`hooks::dx11::ImguiRenderLoop`] trait:
 //!
 //! ```no_run
 //! // lib.rs
-//! use hudhook::hooks::dx11;
+//! use hudhook::hooks::dx11::ImguiRenderLoop;
 //! use hudhook::*;
 //!
 //! pub struct MyRenderLoop;
 //!
-//! impl dx11::ImguiRenderLoop for MyRenderLoop {
+//! impl ImguiRenderLoop for MyRenderLoop {
 //!     fn render(&self, ctx: hudhook::RenderContext) {
 //!         imgui::Window::new(im_str!("My first render loop"))
 //!             .position([0., 0.], imgui::Condition::FirstUseEver)
@@ -63,6 +77,44 @@
 //! hudhook!(MyRenderLoop.into_hook())
 //! ```
 //!
+//! ##### Example: DirectX 12
+//!
+//! Implement the [`hooks::dx12::ImguiRenderLoop`] trait:
+//!
+//! ```no_run
+//! // lib.rs
+//! use hudhook::hooks::dx12::ImguiRenderLoop;
+//! use hudhook::*;
+//!
+//! pub struct MyRenderLoop;
+//!
+//! impl ImguiRenderLoop for MyRenderLoop {
+//!     fn render(&self, ctx: hudhook::RenderContext) {
+//!         imgui::Window::new(im_str!("My first render loop"))
+//!             .position([0., 0.], imgui::Condition::FirstUseEver)
+//!             .size([320., 200.], imgui::Condition::FirstUseEver)
+//!             .build(ctx.frame, || {
+//!                 ctx.frame.text(imgui::im_str!("Hello, hello!"));
+//!             });
+//!     }
+//!
+//!     fn is_visible(&self) -> bool {
+//!         true
+//!     }
+//!
+//!     fn is_capturing(&self) -> bool {
+//!         true
+//!     }
+//! }
+//!
+//! hudhook!(MyRenderLoop.into_hook())
+//! ```
+//!
+//! #### Injecting the DLL
+//!
+//! You can use the facilities in [`inject`] in your binaries to inject
+//! the DLL in your target process.
+//!
 //! ```no_run
 //! // main.rs
 //! use hudhook::inject;
@@ -78,28 +130,29 @@
 //! }
 //! ```
 //!
-//! ### Memory manipulation
-//!
-//! In an initialization step:
-//!
-//! ```no_run
-//! let x = PointerChain::<f32>::new(&[base_address, 0x40, 0x28, 0x80]);
-//! let y = PointerChain::<f32>::new(&[base_address, 0x40, 0x28, 0x88]);
-//! let z = PointerChain::<f32>::new(&[base_address, 0x40, 0x28, 0x84]);
-//! ```
-//!
-//! In the render loop:
-//!
-//! ```no_run
-//! x.read().map(|val| x.write(val + 1.));
-//! y.read().map(|val| y.write(val + 1.));
-//! z.read().map(|val| z.write(val + 1.));
-//! ```
+// //! ### Memory manipulation
+// //!
+// //! In an initialization step:
+// //!
+// //! ```no_run
+// //! let x = PointerChain::<f32>::new(&[base_address, 0x40, 0x28, 0x80]);
+// //! let y = PointerChain::<f32>::new(&[base_address, 0x40, 0x28, 0x88]);
+// //! let z = PointerChain::<f32>::new(&[base_address, 0x40, 0x28, 0x84]);
+// //! ```
+// //!
+// //! In the render loop:
+// //!
+// //! ```no_run
+// //! x.read().map(|val| x.write(val + 1.));
+// //! y.read().map(|val| y.write(val + 1.));
+// //! z.read().map(|val| z.write(val + 1.));
+// //! ```
 #![allow(clippy::needless_doctest_main)]
 
 pub mod hooks;
 pub mod inject;
 
+/// Utility functions.
 pub mod utils {
     use std::sync::atomic::{AtomicBool, Ordering};
 
@@ -138,8 +191,81 @@ pub mod utils {
     }
 }
 
+/// Functions that manage the lifecycle of hooks.
+///
+/// ## Ejecting a DLL
+///
+/// To eject your DLL, invoke the [`eject`] method from anywhere in your
+/// render loop. This will disable the hooks, free the console (if it has
+/// been created before) and invoke `FreeLibraryAndExitThread`.
+///
+/// Befor calling [`eject`], make sure to perform any manual cleanup (e.g.
+/// dropping/resetting the contents of static mutable variables).
+///
+/// [`eject`]: lifecycle::eject
+pub mod lifecycle {
+
+    use std::thread;
+
+    use windows::Win32::System::LibraryLoader::FreeLibraryAndExitThread;
+
+    /// Disable hooks and eject the DLL.
+    pub fn eject() {
+        thread::spawn(|| unsafe {
+            crate::utils::free_console();
+
+            if let Some(mut hooks) = global_state::HOOKS.take() {
+                hooks.unhook();
+            }
+
+            if let Some(module) = global_state::MODULE.take() {
+                FreeLibraryAndExitThread(module, 0);
+            }
+        });
+    }
+
+    /// Exposes functions that store and manipulate global state data.
+    ///
+    /// The functions contained here are automatically invoked by the
+    /// [`hudhook`](crate::hudhook) macro, and are needed to manage the
+    /// hooks' lifetime.
+    ///
+    /// This module is not meant to be used by clients, but it has to be
+    /// exposed as `pub` because the [`hudhook`](crate::hudhook)
+    /// macro generates code in the client's library.
+    pub mod global_state {
+
+        use std::cell::OnceCell;
+
+        use windows::Win32::Foundation::HINSTANCE;
+
+        use crate::hooks;
+
+        pub(super) static mut MODULE: OnceCell<HINSTANCE> = OnceCell::new();
+        pub(super) static mut HOOKS: OnceCell<Box<dyn hooks::Hooks>> = OnceCell::new();
+
+        /// Please don't use me.
+        pub fn set_module(module: HINSTANCE) {
+            unsafe {
+                MODULE.set(module).unwrap();
+            }
+        }
+
+        /// Please don't use me.
+        pub fn get_module() -> HINSTANCE {
+            unsafe { MODULE.get().unwrap().clone() }
+        }
+
+        /// Please don't use me.
+        pub fn set_hooks(hooks: Box<dyn hooks::Hooks>) {
+            unsafe { HOOKS.set(hooks).ok() };
+        }
+    }
+}
+
 pub use log;
 
+/// Convenience reexports for the [macro](crate::hudhook).
 pub mod reexports {
     pub use detour::RawDetour;
     pub use windows::Win32::Foundation::HINSTANCE;
@@ -147,48 +273,11 @@ pub mod reexports {
     pub use windows::Win32::System::SystemServices::{DLL_PROCESS_ATTACH, DLL_PROCESS_DETACH};
 }
 
-pub mod global_state {
-    use std::cell::OnceCell;
-    use std::thread;
-
-    use windows::Win32::Foundation::HINSTANCE;
-    use windows::Win32::System::LibraryLoader::FreeLibraryAndExitThread;
-
-    use crate::{hooks, utils};
-
-    static mut MODULE: OnceCell<HINSTANCE> = OnceCell::new();
-    static mut HOOKS: OnceCell<Box<dyn hooks::Hooks>> = OnceCell::new();
-
-    pub fn set_module(module: HINSTANCE) {
-        unsafe {
-            MODULE.set(module).unwrap();
-        }
-    }
-
-    pub fn get_module() -> HINSTANCE {
-        unsafe { MODULE.get().unwrap().clone() }
-    }
-
-    pub fn set_hooks(hooks: Box<dyn hooks::Hooks>) {
-        unsafe { HOOKS.set(hooks).ok() };
-    }
-
-    pub fn eject() {
-        thread::spawn(|| unsafe {
-            utils::free_console();
-
-            if let Some(mut hooks) = HOOKS.take() {
-                hooks.unhook();
-            }
-
-            if let Some(module) = MODULE.take() {
-                FreeLibraryAndExitThread(module, 0);
-            }
-        });
-    }
-}
-
 /// Entry point for the library.
+///
+/// After implementing your [render loop](crate::hooks) of choice, invoke
+/// the macro to generate the `DllMain` function that will serve as entry point
+/// for your hook.
 ///
 /// Example usage:
 /// ```no_run
@@ -215,35 +304,14 @@ macro_rules! hudhook {
             _: *mut std::ffi::c_void,
         ) {
             if reason == DLL_PROCESS_ATTACH {
-                hudhook::global_state::set_module(hmodule);
+                hudhook::lifecycle::global_state::set_module(hmodule);
 
                 trace!("DllMain()");
                 std::thread::spawn(move || {
                     let hooks: Box<dyn hooks::Hooks> = { $hooks };
                     hooks.hook();
-                    hudhook::global_state::set_hooks(hooks);
-                    // let hooks: Vec<RawDetour> = { $hooks };
-                    // for hook in &hooks {
-                    //     if let Err(e) = hook.enable() {
-                    //         error!("Couldn't enable hook: {e}");
-                    //     }
-                    // }
+                    hudhook::lifecycle::global_state::set_hooks(hooks);
                 });
-            } else if reason == DLL_PROCESS_DETACH {
-                // TODO trigger drops on exit:
-                // - Store _hmodule in a static OnceCell
-                // - Wait for a render loop to be complete
-                // - Call FreeLibraryAndExitThread from a utility function
-                // This branch will then get called.
-                // trace!("Unapplying hooks");
-                // if let Some(mut hooks) = HOOKS.take() {
-                //     hooks.unhook();
-                //     // hooks.iter().for_each(|hook| {
-                //     //     if let Err(e) = hook.disable() {
-                //     //         error!("Error disabling hook: {e}");
-                //     //     }
-                //     // });
-                // }
             }
         }
     };


### PR DESCRIPTION
Closes #3.

Implements the `hudhook::lifecycle::eject()` function to unhook the previously enabled hooks and invoke `FreeLibraryAndExitThread`.

Also adds a refactor and documentation.