### PR TITLE
Reduce code redundancy

### DIFF
--- a/hudhook/src/hooks/common.rs
+++ b/hudhook/src/hooks/common.rs
@@ -11,8 +11,8 @@ pub(crate) type WndProcType =
 
 pub(crate) trait ImguiRendererInterface {
     fn io_mut(&mut self) -> &mut imgui::Io;
-    fn set_focus(&mut self, focus: bool);
-    fn is_focus(&self) -> bool;
+    fn get_focus_mut(&mut self) -> &mut bool;
+    fn get_focus(&self) -> bool;
     fn get_wnd_proc(&self) -> WndProcType;
 
     fn setup_io(&mut self) {
@@ -105,9 +105,9 @@ pub(crate) fn imgui_wnd_proc_impl(
         WM_CHAR => io.add_input_character(wparam as u8 as char),
         WM_ACTIVATE => {
             if loword(wparam as _) == WA_INACTIVE as u16 {
-                imgui_renderer.set_focus(false);
+                *imgui_renderer.get_focus_mut() = false;
             } else {
-                imgui_renderer.set_focus(true);
+                *imgui_renderer.get_focus_mut() = true;
             }
             return LRESULT(1);
         },

--- a/hudhook/src/hooks/common.rs
+++ b/hudhook/src/hooks/common.rs
@@ -1,0 +1,117 @@
+use imgui::*;
+use windows::Win32::Foundation::{HWND, LPARAM, LRESULT, WPARAM};
+use windows::Win32::UI::Input::KeyboardAndMouse::*;
+use windows::Win32::UI::WindowsAndMessaging::{WHEEL_DELTA, WM_XBUTTONDBLCLK, XBUTTON1, *};
+
+pub type WndProcType =
+    unsafe extern "system" fn(hwnd: HWND, umsg: u32, wparam: WPARAM, lparam: LPARAM) -> LRESULT;
+
+pub trait ImguiRendererCommon {
+    fn io_mut(&mut self) -> &mut imgui::Io;
+    fn set_focus(&mut self, focus: bool);
+    fn is_focus(&self) -> bool;
+    fn get_wnd_proc(&self) -> WndProcType;
+
+    fn init_io(&mut self) {
+        let mut io = ImguiRendererCommon::io_mut(self);
+
+        io.nav_active = true;
+        io.nav_visible = true;
+
+        // Initialize keys
+        io[Key::Tab] = VK_TAB.0 as _;
+        io[Key::LeftArrow] = VK_LEFT.0 as _;
+        io[Key::RightArrow] = VK_RIGHT.0 as _;
+        io[Key::UpArrow] = VK_UP.0 as _;
+        io[Key::DownArrow] = VK_DOWN.0 as _;
+        io[Key::PageUp] = VK_PRIOR.0 as _;
+        io[Key::PageDown] = VK_NEXT.0 as _;
+        io[Key::Home] = VK_HOME.0 as _;
+        io[Key::End] = VK_END.0 as _;
+        io[Key::Insert] = VK_INSERT.0 as _;
+        io[Key::Delete] = VK_DELETE.0 as _;
+        io[Key::Backspace] = VK_BACK.0 as _;
+        io[Key::Space] = VK_SPACE.0 as _;
+        io[Key::Enter] = VK_RETURN.0 as _;
+        io[Key::Escape] = VK_ESCAPE.0 as _;
+        io[Key::A] = VK_A.0 as _;
+        io[Key::C] = VK_C.0 as _;
+        io[Key::V] = VK_V.0 as _;
+        io[Key::X] = VK_X.0 as _;
+        io[Key::Y] = VK_Y.0 as _;
+        io[Key::Z] = VK_Z.0 as _;
+    }
+}
+
+pub struct WndProcResult(pub bool, pub Option<LRESULT>);
+
+#[must_use]
+pub(crate) fn imgui_wnd_proc_impl(
+    _hwnd: HWND,
+    umsg: u32,
+    WPARAM(wparam): WPARAM,
+    LPARAM(_lparam): LPARAM,
+    imgui_renderer: &mut Box<impl ImguiRendererCommon>,
+) -> WndProcResult {
+    let mut io = imgui_renderer.io_mut();
+    match umsg {
+        WM_KEYDOWN | WM_SYSKEYDOWN => {
+            if wparam < 256 {
+                io.keys_down[wparam as usize] = true;
+            }
+        },
+        WM_KEYUP | WM_SYSKEYUP => {
+            if wparam < 256 {
+                io.keys_down[wparam as usize] = false;
+            }
+        },
+        WM_LBUTTONDOWN | WM_LBUTTONDBLCLK => {
+            io.mouse_down[0] = true;
+        },
+        WM_RBUTTONDOWN | WM_RBUTTONDBLCLK => {
+            io.mouse_down[1] = true;
+        },
+        WM_MBUTTONDOWN | WM_MBUTTONDBLCLK => {
+            io.mouse_down[2] = true;
+        },
+        WM_XBUTTONDOWN | WM_XBUTTONDBLCLK => {
+            let btn = if super::hiword(wparam as _) == XBUTTON1.0 as u16 { 3 } else { 4 };
+            io.mouse_down[btn] = true;
+        },
+        WM_LBUTTONUP => {
+            io.mouse_down[0] = false;
+        },
+        WM_RBUTTONUP => {
+            io.mouse_down[1] = false;
+        },
+        WM_MBUTTONUP => {
+            io.mouse_down[2] = false;
+        },
+        WM_XBUTTONUP => {
+            let btn = if super::hiword(wparam as _) == XBUTTON1.0 as u16 { 3 } else { 4 };
+            io.mouse_down[btn] = false;
+        },
+        WM_MOUSEWHEEL => {
+            let wheel_delta_wparam = super::get_wheel_delta_wparam(wparam as _);
+            let wheel_delta = WHEEL_DELTA as f32;
+            io.mouse_wheel += (wheel_delta_wparam as i16 as f32) / wheel_delta;
+        },
+        WM_MOUSEHWHEEL => {
+            let wheel_delta_wparam = super::get_wheel_delta_wparam(wparam as _);
+            let wheel_delta = WHEEL_DELTA as f32;
+            io.mouse_wheel_h += (wheel_delta_wparam as i16 as f32) / wheel_delta;
+        },
+        WM_CHAR => io.add_input_character(wparam as u8 as char),
+        WM_ACTIVATE => {
+            if super::loword(wparam as _) == WA_INACTIVE as u16 {
+                imgui_renderer.set_focus(false);
+            } else {
+                imgui_renderer.set_focus(true);
+            }
+            return WndProcResult(bool::default(), Some(LRESULT(1)));
+        },
+        _ => {},
+    };
+
+    return WndProcResult(io.want_capture_mouse || io.want_capture_keyboard, None);
+}

--- a/hudhook/src/hooks/common.rs
+++ b/hudhook/src/hooks/common.rs
@@ -4,10 +4,10 @@ use windows::Win32::Foundation::{HWND, LPARAM, LRESULT, WPARAM};
 use windows::Win32::UI::Input::KeyboardAndMouse::*;
 use windows::Win32::UI::WindowsAndMessaging::{WHEEL_DELTA, WM_XBUTTONDBLCLK, XBUTTON1, *};
 
-pub type WndProcType =
+pub(crate) type WndProcType =
     unsafe extern "system" fn(hwnd: HWND, umsg: u32, wparam: WPARAM, lparam: LPARAM) -> LRESULT;
 
-pub trait ImguiRendererCommon {
+pub(crate) trait ImguiRendererCommon {
     fn io_mut(&mut self) -> &mut imgui::Io;
     fn set_focus(&mut self, focus: bool);
     fn is_focus(&self) -> bool;

--- a/hudhook/src/hooks/dx11.rs
+++ b/hudhook/src/hooks/dx11.rs
@@ -97,7 +97,7 @@ unsafe extern "system" fn imgui_wnd_proc(
 ) -> LRESULT {
     match IMGUI_RENDERER.get().map(Mutex::try_lock) {
         Some(Some(mut imgui_renderer)) => {
-            let WndProcResult(want_capture, optional_result) = imgui_wnd_proc_impl(
+            let WndProcResult(_want_capture, optional_result) = imgui_wnd_proc_impl(
                 hwnd,
                 umsg,
                 WPARAM(wparam),
@@ -112,13 +112,7 @@ unsafe extern "system" fn imgui_wnd_proc(
             let wnd_proc = imgui_renderer.wnd_proc;
             drop(imgui_renderer);
 
-            if want_capture {
-                trace!("Leaving WndProc via capturing");
-                LRESULT(1)
-            } else {
-                trace!("Leaving WndProc via CallWindowProcW");
-                CallWindowProcW(Some(wnd_proc), hwnd, umsg, WPARAM(wparam), LPARAM(lparam))
-            }
+            CallWindowProcW(Some(wnd_proc), hwnd, umsg, WPARAM(wparam), LPARAM(lparam))
         },
         Some(None) => {
             debug!("Could not lock in WndProc");

--- a/hudhook/src/hooks/dx11.rs
+++ b/hudhook/src/hooks/dx11.rs
@@ -97,13 +97,7 @@ unsafe extern "system" fn imgui_wnd_proc(
 ) -> LRESULT {
     match IMGUI_RENDERER.get().map(Mutex::try_lock) {
         Some(Some(imgui_renderer)) => {
-            imgui_wnd_proc_impl(
-                hwnd,
-                umsg,
-                WPARAM(wparam),
-                LPARAM(lparam),
-                imgui_renderer,
-            )
+            imgui_wnd_proc_impl(hwnd, umsg, WPARAM(wparam), LPARAM(lparam), imgui_renderer)
         },
         Some(None) => {
             debug!("Could not lock in WndProc");

--- a/hudhook/src/hooks/dx11.rs
+++ b/hudhook/src/hooks/dx11.rs
@@ -212,11 +212,11 @@ impl ImguiRendererInterface for ImguiRenderer {
         self.ctx().io_mut()
     }
 
-    fn set_focus(&mut self, focus: bool) {
-        self.flags.focused = focus;
+    fn get_focus_mut(&mut self) -> &mut bool {
+        &mut self.flags.focused
     }
 
-    fn is_focus(&self) -> bool {
+    fn get_focus(&self) -> bool {
         self.flags.focused
     }
 

--- a/hudhook/src/hooks/dx11.rs
+++ b/hudhook/src/hooks/dx11.rs
@@ -24,10 +24,8 @@ use windows::Win32::Graphics::Gdi::{ScreenToClient, HBRUSH};
 use windows::Win32::System::LibraryLoader::GetModuleHandleA;
 use windows::Win32::UI::WindowsAndMessaging::*;
 
-use crate::hooks::common::ImguiRendererCommon;
-
-use super::common::{WndProcResult, imgui_wnd_proc_impl};
 use super::Hooks;
+use crate::hooks::common::{imgui_wnd_proc_impl, ImguiRendererCommon, WndProcResult};
 
 type DXGISwapChainPresentType =
     unsafe extern "system" fn(This: IDXGISwapChain, SyncInterval: u32, Flags: u32) -> HRESULT;
@@ -99,7 +97,13 @@ unsafe extern "system" fn imgui_wnd_proc(
 ) -> LRESULT {
     match IMGUI_RENDERER.get().map(Mutex::try_lock) {
         Some(Some(mut imgui_renderer)) => {
-            let WndProcResult(want_capture, optional_result) = imgui_wnd_proc_impl(hwnd, umsg, WPARAM(wparam), LPARAM(lparam), &mut *imgui_renderer);
+            let WndProcResult(want_capture, optional_result) = imgui_wnd_proc_impl(
+                hwnd,
+                umsg,
+                WPARAM(wparam),
+                LPARAM(lparam),
+                &mut *imgui_renderer,
+            );
 
             if let Some(lresult) = optional_result {
                 return lresult;
@@ -166,7 +170,7 @@ impl ImguiRenderer {
         let mut renderer = ImguiRenderer { engine, render_loop, wnd_proc, flags, swap_chain };
 
         ImguiRendererCommon::init_io(&mut renderer);
-        
+
         renderer
     }
 
@@ -404,4 +408,3 @@ impl Hooks for ImguiDX11Hooks {
         drop(IMGUI_RENDER_LOOP.take());
     }
 }
-

--- a/hudhook/src/hooks/dx11.rs
+++ b/hudhook/src/hooks/dx11.rs
@@ -25,7 +25,7 @@ use windows::Win32::System::LibraryLoader::GetModuleHandleA;
 use windows::Win32::UI::WindowsAndMessaging::*;
 
 use super::Hooks;
-use crate::hooks::common::{imgui_wnd_proc_impl, ImguiRendererCommon};
+use crate::hooks::common::{imgui_wnd_proc_impl, ImguiRendererInterface};
 
 type DXGISwapChainPresentType =
     unsafe extern "system" fn(This: IDXGISwapChain, SyncInterval: u32, Flags: u32) -> HRESULT;
@@ -148,7 +148,7 @@ impl ImguiRenderer {
         trace!("Renderer initialized");
         let mut renderer = ImguiRenderer { engine, render_loop, wnd_proc, flags, swap_chain };
 
-        ImguiRendererCommon::init_io(&mut renderer);
+        ImguiRendererInterface::setup_io(&mut renderer);
 
         renderer
     }
@@ -207,7 +207,7 @@ impl ImguiRenderer {
     }
 }
 
-impl crate::hooks::common::ImguiRendererCommon for ImguiRenderer {
+impl ImguiRendererInterface for ImguiRenderer {
     fn io_mut(&mut self) -> &mut imgui::Io {
         self.ctx().io_mut()
     }
@@ -220,7 +220,7 @@ impl crate::hooks::common::ImguiRendererCommon for ImguiRenderer {
         self.flags.focused
     }
 
-    fn get_wnd_proc(&self) -> crate::hooks::common::WndProcType {
+    fn get_wnd_proc(&self) -> WndProcType {
         self.wnd_proc
     }
 }

--- a/hudhook/src/hooks/dx12.rs
+++ b/hudhook/src/hooks/dx12.rs
@@ -23,7 +23,7 @@ use windows::Win32::System::LibraryLoader::GetModuleHandleA;
 use windows::Win32::UI::WindowsAndMessaging::*;
 
 use super::Hooks;
-use crate::hooks::common::{imgui_wnd_proc_impl, ImguiRendererCommon, WndProcType};
+use crate::hooks::common::{imgui_wnd_proc_impl, ImguiRendererInterface, WndProcType};
 
 type DXGISwapChainPresentType =
     unsafe extern "system" fn(This: IDXGISwapChain3, SyncInterval: u32, Flags: u32) -> HRESULT;
@@ -329,7 +329,7 @@ impl ImguiRenderer {
             swap_chain,
         };
 
-        ImguiRendererCommon::init_io(&mut renderer);
+        ImguiRendererInterface::setup_io(&mut renderer);
 
         renderer
     }
@@ -453,7 +453,7 @@ impl ImguiRenderer {
     }
 }
 
-impl ImguiRendererCommon for ImguiRenderer {
+impl ImguiRendererInterface for ImguiRenderer {
     fn io_mut(&mut self) -> &mut imgui::Io {
         self.ctx.io_mut()
     }

--- a/hudhook/src/hooks/dx12.rs
+++ b/hudhook/src/hooks/dx12.rs
@@ -207,7 +207,7 @@ unsafe extern "system" fn imgui_wnd_proc(
 
     match IMGUI_RENDERER.get().map(Mutex::try_lock) {
         Some(Some(mut imgui_renderer)) => {
-            let WndProcResult(want_capture, optional_result) = imgui_wnd_proc_impl(hwnd, umsg, WPARAM(wparam), LPARAM(lparam), &mut *imgui_renderer);
+            let WndProcResult(_want_capture, optional_result) = imgui_wnd_proc_impl(hwnd, umsg, WPARAM(wparam), LPARAM(lparam), &mut *imgui_renderer);
 
             if let Some(lresult) = optional_result {
                 return lresult;
@@ -216,13 +216,7 @@ unsafe extern "system" fn imgui_wnd_proc(
             let wnd_proc = imgui_renderer.wnd_proc;
             drop(imgui_renderer);
 
-            if want_capture {
-                trace!("Leaving WndProc via capturing");
-                LRESULT(1)
-            } else {
-                trace!("Leaving WndProc via CallWindowProcW");
-                CallWindowProcW(Some(wnd_proc), hwnd, umsg, WPARAM(wparam), LPARAM(lparam))
-            }
+            CallWindowProcW(Some(wnd_proc), hwnd, umsg, WPARAM(wparam), LPARAM(lparam))
         },
         Some(None) => {
             debug!("Could not lock in WndProc");

--- a/hudhook/src/hooks/dx12.rs
+++ b/hudhook/src/hooks/dx12.rs
@@ -458,11 +458,11 @@ impl ImguiRendererInterface for ImguiRenderer {
         self.ctx.io_mut()
     }
 
-    fn set_focus(&mut self, focus: bool) {
-        self.flags.focused = focus;
+    fn get_focus_mut(&mut self) -> &mut bool {
+        &mut self.flags.focused
     }
 
-    fn is_focus(&self) -> bool {
+    fn get_focus(&self) -> bool {
         self.flags.focused
     }
 

--- a/hudhook/src/hooks/dx12.rs
+++ b/hudhook/src/hooks/dx12.rs
@@ -22,10 +22,8 @@ use windows::Win32::Graphics::Gdi::{ScreenToClient, HBRUSH};
 use windows::Win32::System::LibraryLoader::GetModuleHandleA;
 use windows::Win32::UI::WindowsAndMessaging::*;
 
-use crate::hooks::common::ImguiRendererCommon;
-use crate::hooks::common::{WndProcType, imgui_wnd_proc_impl};
-
 use super::Hooks;
+use crate::hooks::common::{imgui_wnd_proc_impl, ImguiRendererCommon, WndProcType};
 
 type DXGISwapChainPresentType =
     unsafe extern "system" fn(This: IDXGISwapChain3, SyncInterval: u32, Flags: u32) -> HRESULT;
@@ -207,13 +205,7 @@ unsafe extern "system" fn imgui_wnd_proc(
 
     match IMGUI_RENDERER.get().map(Mutex::try_lock) {
         Some(Some(imgui_renderer)) => {
-            imgui_wnd_proc_impl(
-                hwnd,
-                umsg,
-                WPARAM(wparam),
-                LPARAM(lparam),
-                imgui_renderer,
-            )
+            imgui_wnd_proc_impl(hwnd, umsg, WPARAM(wparam), LPARAM(lparam), imgui_renderer)
         },
         Some(None) => {
             debug!("Could not lock in WndProc");
@@ -318,7 +310,6 @@ impl ImguiRenderer {
         ));
 
         ctx.set_ini_filename(None);
-
 
         let flags = ImguiRenderLoopFlags { focused: true };
 

--- a/hudhook/src/hooks/mod.rs
+++ b/hudhook/src/hooks/mod.rs
@@ -5,9 +5,9 @@
 //!
 //! [`imgui`]: https://docs.rs/imgui/0.8.0/imgui/
 
+pub(crate) mod common;
 pub mod dx11;
 pub mod dx12;
-pub(crate) mod common;
 
 /// Generic trait for platform-specific hooks.
 pub trait Hooks {

--- a/hudhook/src/hooks/mod.rs
+++ b/hudhook/src/hooks/mod.rs
@@ -7,6 +7,7 @@
 
 pub mod dx11;
 pub mod dx12;
+pub(crate) mod common;
 
 /// Generic trait for platform-specific hooks.
 pub trait Hooks {


### PR DESCRIPTION
This is an attempt to reduce a bit code redundancy.

Although this is a bit unnecessary, I've already noticed a few discrepancies between the DX11 and DX12 implementations that actually do the same thing, like DX11 using some functions that DX12 doesn't, and the IO was un-synchronized for DX11 before my PR.

This is more a proposal rather than a fix. With this format, it's more harder to have different WndProc for both implementations so they can be better in sync.

I'm open to discuss this if it's something you'd be up to improve further on or simply drop it.

The `imgui_wnd_proc` is statically dispatched so it should have virtually no performance impact.