### PR TITLE
Partially revert 21f043d

### DIFF
--- a/hudhook/src/hooks/dx12.rs
+++ b/hudhook/src/hooks/dx12.rs
@@ -270,17 +270,12 @@ unsafe extern "system" fn imgui_wnd_proc(
                 _ => {},
             }
 
-            let want_capture = io.want_capture_mouse || io.want_capture_keyboard;
             let wnd_proc = imgui_renderer.wnd_proc;
             drop(imgui_renderer);
 
-            if want_capture {
-                trace!("Leaving WndProc via capturing");
-                LRESULT(1)
-            } else {
-                trace!("Leaving WndProc via CallWindowProcW");
-                CallWindowProcW(Some(wnd_proc), hwnd, umsg, WPARAM(wparam), LPARAM(lparam))
-            }
+            trace!("Leaving WndProc");
+
+            CallWindowProcW(Some(wnd_proc), hwnd, umsg, WPARAM(wparam), LPARAM(lparam))
         },
         Some(None) => {
             debug!("Could not lock in WndProc");


### PR DESCRIPTION
This patch crashes The Witcher 3 due to the chain of wnd_proc being
broken, so messages don't arrive to the parent window.

I'd say to properly ignore incoming messages would be to override the `wnd_proc` of the game itself, and peek the message.