### PR TITLE
Inject overhaul

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,7 @@ windows = { version = "0.39.0", features = [
   "Win32_Security",
   "Win32_System_Console",
   "Win32_System_Diagnostics_Debug",
+  "Win32_System_Diagnostics_ToolHelp",
   "Win32_System_LibraryLoader",
   "Win32_System_Memory",
   "Win32_System_ProcessStatus",

--- a/src/inject.rs
+++ b/src/inject.rs
@@ -1,8 +1,8 @@
 //! Facilities for injecting compiled DLLs into target processes.
 
-use std::ffi::{CStr, CString, OsString};
+use std::ffi::{CStr, CString};
 use std::mem::{self, size_of};
-use std::os::windows::prelude::{OsStrExt, OsStringExt};
+
 use std::path::PathBuf;
 use std::ptr::{null, null_mut};
 

--- a/src/inject.rs
+++ b/src/inject.rs
@@ -2,7 +2,6 @@
 
 use std::ffi::{CStr, CString};
 use std::mem::{self, size_of};
-
 use std::path::PathBuf;
 use std::ptr::{null, null_mut};
 

--- a/tests/inject.rs
+++ b/tests/inject.rs
@@ -10,7 +10,10 @@ fn test_inject_by_title() {
     std::thread::sleep(Duration::from_millis(500));
     println!("Should show a message box that says \"Hello\".");
 
-    Process::by_title("Untitled - Notepad").unwrap().inject(examples_path().join("dummy_hook.dll")).unwrap();
+    Process::by_title("Untitled - Notepad")
+        .unwrap()
+        .inject(examples_path().join("dummy_hook.dll"))
+        .unwrap();
 
     std::thread::sleep(Duration::from_millis(1000));
     child.kill().expect("Couldn't kill notepad");
@@ -22,7 +25,10 @@ fn test_inject_by_name() {
     std::thread::sleep(Duration::from_millis(500));
     println!("Should show a message box that says \"Hello\".");
 
-    Process::by_name("Notepad.exe").unwrap().inject(examples_path().join("dummy_hook.dll")).unwrap();
+    Process::by_name("Notepad.exe")
+        .unwrap()
+        .inject(examples_path().join("dummy_hook.dll"))
+        .unwrap();
 
     std::thread::sleep(Duration::from_millis(1000));
     child.kill().expect("Couldn't kill notepad");

--- a/tests/inject.rs
+++ b/tests/inject.rs
@@ -2,15 +2,27 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::Duration;
 
-use hudhook::inject::inject;
+use hudhook::inject::Process;
 
 #[test]
-fn test_inject() {
+fn test_inject_by_title() {
     let mut child = Command::new("notepad.exe").spawn().expect("Couldn't start notepad");
     std::thread::sleep(Duration::from_millis(500));
     println!("Should show a message box that says \"Hello\".");
 
-    inject("Untitled - Notepad", examples_path().join("dummy_hook.dll")).unwrap();
+    Process::by_title("Untitled - Notepad").unwrap().inject(examples_path().join("dummy_hook.dll")).unwrap();
+
+    std::thread::sleep(Duration::from_millis(1000));
+    child.kill().expect("Couldn't kill notepad");
+}
+
+#[test]
+fn test_inject_by_name() {
+    let mut child = Command::new("notepad.exe").spawn().expect("Couldn't start notepad");
+    std::thread::sleep(Duration::from_millis(500));
+    println!("Should show a message box that says \"Hello\".");
+
+    Process::by_name("Notepad.exe").unwrap().inject(examples_path().join("dummy_hook.dll")).unwrap();
 
     std::thread::sleep(Duration::from_millis(1000));
     child.kill().expect("Couldn't kill notepad");


### PR DESCRIPTION
Introduces a `Project` struct to control injection. Injection is now performed as follows:

```rust
Process::by_name("notepad.exe").inject(dll_path);
Process::by_title("Untitled - Notepad").inject(dll_path);
```