### PR TITLE
Fix for drawing more than 64k draw commands

### DIFF
--- a/src/renderers/imgui_dx12.rs
+++ b/src/renderers/imgui_dx12.rs
@@ -340,14 +340,12 @@ impl RenderEngine {
                                 cmd_list.DrawIndexedInstanced(
                                     count as _,
                                     1,
-                                    idx_offset as _,
-                                    vtx_offset as _,
+                                    (cmd_params.idx_offset + idx_offset) as _,
+                                    (cmd_params.vtx_offset + vtx_offset) as _,
                                     0,
                                 );
                             }
                         }
-
-                        idx_offset += count;
                     },
                     DrawCmd::ResetRenderState => {
                         self.setup_render_state(draw_data, cmd_list, frame_resources_idx);
@@ -357,6 +355,7 @@ impl RenderEngine {
                     },
                 }
             }
+            idx_offset += cl.idx_buffer().len();
             vtx_offset += cl.vtx_buffer().len();
         }
 


### PR DESCRIPTION
In ImGui there was once a limitation with more than 64k vertexes. To fix this you set this flag
`ctx.io_mut().backend_flags |= BackendFlags::RENDERER_HAS_VTX_OFFSET;`
Which was already done correctly in hudhook, however you need to then use the DrawCmd VtxOffset value when iterating through the draw commands.

For reference:
https://skia.googlesource.com/external/github.com/ocornut/imgui/+/refs/heads/features/draw_callback_extra_arg/examples/imgui_impl_dx12.cpp#231