### PR TITLE
Remap shift/ctrl/menu virtual keys

### DIFF
--- a/src/hooks/common.rs
+++ b/src/hooks/common.rs
@@ -108,7 +108,6 @@ where
             // logic isn't flawed either.
             //
             // [1] https://github.com/imgui-rs/imgui-rs/blob/b1e66d050e84dbb2120001d16ce59d15ef6b5303/imgui-winit-support/src/lib.rs#L401-L404
-            // let key_pressed = VIRTUAL_KEY(wparam as u16); // key pressed already mapped above
             match key_pressed {
                 VK_CONTROL | VK_LCONTROL | VK_RCONTROL => io.key_ctrl = pressed,
                 VK_SHIFT | VK_LSHIFT | VK_RSHIFT => io.key_shift = pressed,

--- a/tests/dx11.rs
+++ b/tests/dx11.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 use harness::dx11::Dx11Harness;
 use hudhook::hooks::dx11::ImguiDx11Hooks;
 use hudhook::hooks::{self, ImguiRenderLoop, ImguiRenderLoopFlags};
-use imgui::Condition;
+use imgui::{Condition, StyleColor};
 use simplelog::*;
 
 #[test]
@@ -28,6 +28,25 @@ fn test_imgui_dx11() {
                 ui.text("Hello world!");
                 ui.text("こんにちは世界！");
                 ui.text("This...is...imgui-rs!");
+                for y in 0..16 {
+                    for x in 0..16 {
+                        let btn = y * 16 + x;
+                        let _token = ui.push_style_color(
+                            StyleColor::Text,
+                            if ui.io().keys_down[btn as usize] {
+                                [0., 1., 0., 1.]
+                            } else {
+                                [1., 1., 1., 1.]
+                            },
+                        );
+                        ui.text(format!("{btn:02x}"));
+                        ui.same_line();
+                    }
+                    ui.new_line();
+                }
+                ui.text(if ui.io().key_shift { "SHIFT" } else { "shift" });
+                ui.text(if ui.io().key_ctrl { "CTRL" } else { "ctrl" });
+                ui.text(if ui.io().key_alt { "ALT" } else { "alt" });
                 ui.separator();
                 let mouse_pos = ui.io().mouse_pos;
                 ui.text(format!("Mouse Position: ({:.1},{:.1})", mouse_pos[0], mouse_pos[1]));


### PR DESCRIPTION
This PR adds a mapping between non-specific modifier keys (e.g. VK_SHIFT) and their concrete respective (eg. VK_RSHIFT and VK_LSHIFT).