### PR TITLE
DX11 feature level 10 support

### DIFF
--- a/src/hooks/dx11.rs
+++ b/src/hooks/dx11.rs
@@ -10,7 +10,9 @@ use windows::core::{Interface, HRESULT};
 use windows::Win32::Foundation::{
     GetLastError, BOOL, HANDLE, HWND, LPARAM, LRESULT, POINT, WPARAM,
 };
-use windows::Win32::Graphics::Direct3D::{D3D_DRIVER_TYPE_HARDWARE, D3D_FEATURE_LEVEL_10_0, D3D_FEATURE_LEVEL_11_0};
+use windows::Win32::Graphics::Direct3D::{
+    D3D_DRIVER_TYPE_HARDWARE, D3D_FEATURE_LEVEL_10_0, D3D_FEATURE_LEVEL_11_0,
+};
 use windows::Win32::Graphics::Direct3D11::{
     D3D11CreateDeviceAndSwapChain, ID3D11Device, ID3D11DeviceContext, D3D11_CREATE_DEVICE_FLAG,
     D3D11_SDK_VERSION,

--- a/src/hooks/dx11.rs
+++ b/src/hooks/dx11.rs
@@ -10,7 +10,7 @@ use windows::core::{Interface, HRESULT};
 use windows::Win32::Foundation::{
     GetLastError, BOOL, HANDLE, HWND, LPARAM, LRESULT, POINT, WPARAM,
 };
-use windows::Win32::Graphics::Direct3D::{D3D_DRIVER_TYPE_HARDWARE, D3D_FEATURE_LEVEL_11_0};
+use windows::Win32::Graphics::Direct3D::{D3D_DRIVER_TYPE_HARDWARE, D3D_FEATURE_LEVEL_10_0, D3D_FEATURE_LEVEL_11_0};
 use windows::Win32::Graphics::Direct3D11::{
     D3D11CreateDeviceAndSwapChain, ID3D11Device, ID3D11DeviceContext, D3D11_CREATE_DEVICE_FLAG,
     D3D11_SDK_VERSION,
@@ -310,7 +310,7 @@ fn get_present_addr() -> (DXGISwapChainPresentType, DXGISwapChainResizeBuffersTy
             D3D_DRIVER_TYPE_HARDWARE,
             None,
             D3D11_CREATE_DEVICE_FLAG(0),
-            &[D3D_FEATURE_LEVEL_11_0],
+            &[D3D_FEATURE_LEVEL_10_0, D3D_FEATURE_LEVEL_11_0],
             D3D11_SDK_VERSION,
             &DXGI_SWAP_CHAIN_DESC {
                 BufferDesc: DXGI_MODE_DESC {


### PR DESCRIPTION
Some computers does not fully support DX11 feature level 11.0, 10.0 does. By adding feature level 10, this will prevent an error in creating `D3D11Device & SwapChain` in those machines. 