### PR TITLE
Fix DX9 early inject crash

### DIFF
--- a/src/hooks/dx9.rs
+++ b/src/hooks/dx9.rs
@@ -10,7 +10,7 @@ use windows::Win32::Foundation::{
 };
 use windows::Win32::Graphics::Direct3D9::{
     Direct3DCreate9, IDirect3DDevice9, D3DADAPTER_DEFAULT, D3DBACKBUFFER_TYPE_MONO,
-    D3DCREATE_SOFTWARE_VERTEXPROCESSING, D3DDEVTYPE_HAL, D3DDISPLAYMODE, D3DFORMAT,
+    D3DCREATE_SOFTWARE_VERTEXPROCESSING, D3DDEVTYPE_NULLREF, D3DDISPLAYMODE, D3DFORMAT,
     D3DPRESENT_PARAMETERS, D3DSWAPEFFECT_DISCARD, D3D_SDK_VERSION,
 };
 use windows::Win32::Graphics::Gdi::{ScreenToClient, RGNDATA};
@@ -315,7 +315,7 @@ unsafe fn get_dx9_present_addr() -> (Dx9EndSceneFn, Dx9PresentFn, Dx9ResetFn) {
     let mut device: Option<IDirect3DDevice9> = None;
     d9.CreateDevice(
         D3DADAPTER_DEFAULT,
-        D3DDEVTYPE_HAL,
+        D3DDEVTYPE_NULLREF,
         GetDesktopWindow(),
         D3DCREATE_SOFTWARE_VERTEXPROCESSING as u32,
         &mut present_params,

--- a/src/inject.rs
+++ b/src/inject.rs
@@ -256,7 +256,8 @@ mod tests {
     #[test]
     #[ignore]
     fn test_get_process_by_title() {
-        // Notepad doesn't expose its title anymore, so we ignore this test for the time being.
+        // Notepad doesn't expose its title anymore, so we ignore this test for the time
+        // being.
         let mut child = Command::new("Notepad.exe").spawn().expect("Couldn't start notepad");
         std::thread::sleep(Duration::from_millis(500));
 

--- a/tests/inject.rs
+++ b/tests/inject.rs
@@ -7,7 +7,8 @@ use hudhook::inject::Process;
 #[test]
 #[ignore]
 fn test_inject_by_title() {
-    // Notepad doesn't expose its title anymore, so we ignore this test for the time being.
+    // Notepad doesn't expose its title anymore, so we ignore this test for the time
+    // being.
     let mut child = Command::new("notepad.exe").spawn().expect("Couldn't start notepad");
     std::thread::sleep(Duration::from_millis(500));
     println!("Should show a message box that says \"Hello\".");


### PR DESCRIPTION
This PR fixes an early injection crash that I have (knowingly) only experienced in Fallout 3, but it likely happens in others too.

I honestly am not sure why this works, but changing the d3d9 devicetype from `D3DDEVTYPE_HAL` to `D3DDEVTYPE_NULLREF` makes it stop.

I tested it on 10+ DX9 games without experiencing side-effects, so it should be okay to do this.

Below is the crash I get with `D3DDEVTYPE_HAL`;
![image](https://user-images.githubusercontent.com/17499594/234058952-f598a8d0-0bc7-4bf4-8a6f-4cb01422e8a6.png)
