### PR TITLE
Reexport imgui

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -239,6 +239,7 @@ pub mod lifecycle {
     }
 }
 
+pub use imgui;
 pub use tracing;
 
 /// Convenience reexports for the [macro](crate::hudhook).


### PR DESCRIPTION
Reexport `imgui` as a convenience so client libraries can have consistent versioning.