### PR TITLE
Add tracing feature 'log'

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,7 +98,7 @@ windows = { version = "0.39.0", features = [
   "Win32_UI_Input_KeyboardAndMouse",
   "Win32_UI_WindowsAndMessaging",
 ] }
-tracing = "0.1"
+tracing = { version = "0.1", features = ["log"] }
 
 [dev-dependencies]
 tracing-subscriber = "0.3"

--- a/src/hooks/dx11.rs
+++ b/src/hooks/dx11.rs
@@ -11,7 +11,7 @@ use windows::Win32::Foundation::{
     GetLastError, BOOL, HANDLE, HWND, LPARAM, LRESULT, POINT, WPARAM,
 };
 use windows::Win32::Graphics::Direct3D::{
-    D3D_FEATURE_LEVEL_10_0, D3D_FEATURE_LEVEL_11_0, D3D_DRIVER_TYPE_NULL,
+    D3D_DRIVER_TYPE_NULL, D3D_FEATURE_LEVEL_10_0, D3D_FEATURE_LEVEL_11_0,
 };
 use windows::Win32::Graphics::Direct3D11::{
     D3D11CreateDeviceAndSwapChain, ID3D11Device, ID3D11DeviceContext, D3D11_CREATE_DEVICE_FLAG,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -239,8 +239,7 @@ pub mod lifecycle {
     }
 }
 
-pub use imgui;
-pub use tracing;
+pub use {imgui, tracing};
 
 /// Convenience reexports for the [macro](crate::hudhook).
 pub mod reexports {


### PR DESCRIPTION
We just need to add the feature "log" to tracing and it will automatically use log if no tracing subscriber is active. More info [here](https://docs.rs/tracing/0.1.29/tracing/index.html#log-compatibilityl).

Thoughts? Works flawlessly :)