### PR TITLE
Fix OpenGL resizing

### DIFF
--- a/src/hooks/opengl3.rs
+++ b/src/hooks/opengl3.rs
@@ -10,7 +10,7 @@ use windows::Win32::Foundation::{
     GetLastError, BOOL, HANDLE, HWND, LPARAM, LRESULT, POINT, RECT, WPARAM,
 };
 use windows::Win32::Graphics::Gdi::{ScreenToClient, WindowFromDC, HDC};
-use windows::Win32::Graphics::OpenGL::{glGetIntegerv, GL_VIEWPORT};
+use windows::Win32::Graphics::OpenGL::{glClearColor, glGetIntegerv, GL_VIEWPORT};
 use windows::Win32::System::LibraryLoader::{GetModuleHandleA, GetProcAddress};
 #[cfg(target_arch = "x86")]
 use windows::Win32::UI::WindowsAndMessaging::SetWindowLongA;
@@ -150,6 +150,7 @@ unsafe fn reset(hdc: HDC) {
         if let Some(renderer) = IMGUI_RENDERER.take() {
             renderer.lock().cleanup();
             RESOLUTION_AND_RECT.take();
+            glClearColor(0.0, 0.0, 0.0, 1.0);
         }
     }
 }


### PR DESCRIPTION
This PR will fix ImGui not resetting & thus disappearing in some games when a resize, resolution change or ALT + TAB happens.

We have to compare resolution because some older games (like CS 1.6) don't trigger any window resize when it is in fullscreen and the user changes resolution.

We have to compare window rect because ALT + TAB'ing and changing from windowed to/from fullscreen doesn't always trigger resolution change.

---

The only issue I have noticed so far is that after a bunch of resizes it is possible that everything ImGui renders goes completely black. If you resize again it is possible that it disappears.
I assume there is something more needed for the reset on the OpenGL end - maybe `glClearColor`?

![image](https://user-images.githubusercontent.com/17499594/236534577-f35d0e29-a3ef-4412-837d-73865bdb9142.png)
