### PR TITLE
Bump windows-rs to 0.48.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,7 +98,7 @@ windows = { version = "0.39.0", features = [
   "Win32_UI_Input_KeyboardAndMouse",
   "Win32_UI_WindowsAndMessaging",
 ] }
-tracing = "0.1"
+tracing = { version = "0.1", features = ["log"] }
 
 [dev-dependencies]
 tracing-subscriber = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ memoffset = "0.6.5"
 once_cell = "1.8.0"
 parking_lot = "0.11.2"
 widestring = "1.0.1"
-windows = { version = "0.39.0", features = [
+windows = { version = "0.48.0", features = [
   "Win32_Devices_HumanInterfaceDevice",
   "Win32_Foundation",
   "Win32_Security",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,6 +97,7 @@ windows = { version = "0.48.0", features = [
   "Win32_Graphics_OpenGL",
   "Win32_UI_Input_KeyboardAndMouse",
   "Win32_UI_WindowsAndMessaging",
+  "Foundation_Numerics",
 ] }
 tracing = { version = "0.1", features = ["log"] }
 

--- a/examples/dummy_hook.rs
+++ b/examples/dummy_hook.rs
@@ -1,11 +1,11 @@
-use hudhook::reexports::{DLL_PROCESS_ATTACH, HINSTANCE};
+use hudhook::reexports::{DLL_PROCESS_ATTACH, HMODULE};
 use windows::core::PCSTR;
 use windows::Win32::Foundation::HWND;
 use windows::Win32::UI::WindowsAndMessaging::{MessageBoxA, MB_OK};
 
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub unsafe extern "stdcall" fn DllMain(_: HINSTANCE, reason: u32, _: *mut std::ffi::c_void) {
+pub unsafe extern "stdcall" fn DllMain(_: HMODULE, reason: u32, _: *mut std::ffi::c_void) {
     if reason == DLL_PROCESS_ATTACH {
         std::thread::spawn(move || {
             MessageBoxA(HWND(0), PCSTR("Hello\0".as_ptr()), PCSTR("Hello\0".as_ptr()), MB_OK)

--- a/examples/dx11_host.rs
+++ b/examples/dx11_host.rs
@@ -51,7 +51,7 @@ pub fn main(_argc: i32, _argv: *const *const u8) {
             HWND(0),   // hWndParent
             HMENU(0),  // hMenu
             hinstance, // hInstance
-            null(),
+            None,
         )
     }; // lpParam
 
@@ -80,10 +80,10 @@ pub fn main(_argc: i32, _argv: *const *const u8) {
         unsafe {
             for i in 0..diq.GetNumStoredMessages(DXGI_DEBUG_ALL) {
                 let mut msg_len: usize = 0;
-                diq.GetMessage(DXGI_DEBUG_ALL, i, null_mut(), &mut msg_len as _).unwrap();
+                diq.GetMessage(DXGI_DEBUG_ALL, i, None, &mut msg_len as _).unwrap();
                 let diqm = vec![0u8; msg_len];
                 let pdiqm = diqm.as_ptr() as *mut DXGI_INFO_QUEUE_MESSAGE;
-                diq.GetMessage(DXGI_DEBUG_ALL, i, pdiqm, &mut msg_len as _).unwrap();
+                diq.GetMessage(DXGI_DEBUG_ALL, i, Some(pdiqm), &mut msg_len as _).unwrap();
                 let diqm = pdiqm.as_ref().unwrap();
                 println!(
                     "{}",
@@ -132,7 +132,7 @@ pub unsafe extern "system" fn window_proc(
             GetClientRect(hwnd, rect.as_mut_ptr());
             DrawTextA(
                 hdc,
-                "Test\0".as_bytes(),
+                &mut "Test\0".as_bytes().to_owned(),
                 rect.as_mut_ptr(),
                 DT_SINGLELINE | DT_CENTER | DT_VCENTER,
             );

--- a/examples/dx11_host.rs
+++ b/examples/dx11_host.rs
@@ -4,7 +4,7 @@
 #![no_main]
 
 use std::mem::MaybeUninit;
-use std::ptr::{null, null_mut};
+use std::ptr::null;
 
 use windows::core::{PCSTR, PCWSTR};
 use windows::Win32::Foundation::{HWND, LPARAM, LRESULT, WPARAM};

--- a/examples/renderers/dx11.rs
+++ b/examples/renderers/dx11.rs
@@ -62,7 +62,7 @@ pub fn main(_argc: i32, _argv: *const *const u8) {
             HWND(0),   // hWndParent
             HMENU(0),  // hMenu
             hinstance, // hInstance
-            null(),
+            None,
         )
     }; // lpParam
 
@@ -80,10 +80,10 @@ pub fn main(_argc: i32, _argv: *const *const u8) {
             for i in 0..diq.GetNumStoredMessages(DXGI_DEBUG_ALL) {
                 eprintln!("Debug Message {i}");
                 let mut msg_len: usize = 0;
-                diq.GetMessage(DXGI_DEBUG_ALL, i, null_mut(), &mut msg_len as _).unwrap();
+                diq.GetMessage(DXGI_DEBUG_ALL, i, None, &mut msg_len as _).unwrap();
                 let diqm = vec![0u8; msg_len];
                 let pdiqm = diqm.as_ptr() as *mut DXGI_INFO_QUEUE_MESSAGE;
-                diq.GetMessage(DXGI_DEBUG_ALL, i, pdiqm, &mut msg_len as _).unwrap();
+                diq.GetMessage(DXGI_DEBUG_ALL, i, Some(pdiqm), &mut msg_len as _).unwrap();
                 let diqm = pdiqm.as_ref().unwrap();
                 eprintln!(
                     "{}",
@@ -165,7 +165,7 @@ pub unsafe extern "system" fn window_proc(
             GetClientRect(hwnd, rect.as_mut_ptr());
             DrawTextA(
                 hdc,
-                "Test\0".as_bytes(),
+                &mut "Test\0".as_bytes().to_owned(),
                 rect.as_mut_ptr(),
                 DT_SINGLELINE | DT_CENTER | DT_VCENTER,
             );

--- a/examples/renderers/dx11.rs
+++ b/examples/renderers/dx11.rs
@@ -4,7 +4,7 @@
 #![no_main]
 
 use std::mem::MaybeUninit;
-use std::ptr::{null, null_mut};
+use std::ptr::null_mut;
 
 use hudhook::renderers::imgui_dx11::RenderEngine;
 use imgui::Condition;

--- a/examples/renderers/dx12.rs
+++ b/examples/renderers/dx12.rs
@@ -4,7 +4,7 @@
 #![no_main]
 
 use std::mem::MaybeUninit;
-use std::ptr::{null, null_mut};
+use std::ptr::null;
 
 use hudhook::renderers::imgui_dx12::RenderEngine;
 use imgui::Condition;

--- a/examples/renderers/dx9.rs
+++ b/examples/renderers/dx9.rs
@@ -128,7 +128,7 @@ pub fn main(_argc: i32, _argv: *const *const u8) {
             HWND(0),
             HMENU(0),
             hinstance,
-            null(),
+            None,
         )
     };
 
@@ -148,10 +148,10 @@ pub fn main(_argc: i32, _argv: *const *const u8) {
             for i in 0..diq.GetNumStoredMessages(DXGI_DEBUG_ALL) {
                 eprintln!("Debug Message {i}");
                 let mut msg_len: usize = 0;
-                diq.GetMessage(DXGI_DEBUG_ALL, i, null_mut(), &mut msg_len as _).unwrap();
+                diq.GetMessage(DXGI_DEBUG_ALL, i, None, &mut msg_len as _).unwrap();
                 let diqm = vec![0u8; msg_len];
                 let pdiqm = diqm.as_ptr() as *mut DXGI_INFO_QUEUE_MESSAGE;
-                diq.GetMessage(DXGI_DEBUG_ALL, i, pdiqm, &mut msg_len as _).unwrap();
+                diq.GetMessage(DXGI_DEBUG_ALL, i, Some(pdiqm), &mut msg_len as _).unwrap();
                 let diqm = pdiqm.as_ref().unwrap();
                 eprintln!(
                     "{}",

--- a/examples/renderers/dx9.rs
+++ b/examples/renderers/dx9.rs
@@ -23,7 +23,7 @@
 #![no_main]
 
 use std::mem::MaybeUninit;
-use std::ptr::{null, null_mut};
+use std::ptr::null_mut;
 
 use hudhook::renderers::imgui_dx9::Renderer;
 use imgui::Condition;

--- a/src/hooks/common.rs
+++ b/src/hooks/common.rs
@@ -126,7 +126,7 @@ where
             io.mouse_down[2] = true;
         },
         WM_XBUTTONDOWN | WM_XBUTTONDBLCLK => {
-            let btn = if hiword(wparam as _) == XBUTTON1.0 as u16 { 3 } else { 4 };
+            let btn = if hiword(wparam as _) == XBUTTON1 { 3 } else { 4 };
             io.mouse_down[btn] = true;
         },
         WM_LBUTTONUP => {
@@ -139,7 +139,7 @@ where
             io.mouse_down[2] = false;
         },
         WM_XBUTTONUP => {
-            let btn = if hiword(wparam as _) == XBUTTON1.0 as u16 { 3 } else { 4 };
+            let btn = if hiword(wparam as _) == XBUTTON1 { 3 } else { 4 };
             io.mouse_down[btn] = false;
         },
         WM_MOUSEWHEEL => {

--- a/src/hooks/dx11.rs
+++ b/src/hooks/dx11.rs
@@ -168,7 +168,7 @@ impl ImguiRenderer {
         trace!("Initializing renderer");
 
         let dev: ID3D11Device = swap_chain.GetDevice().expect("GetDevice");
-        let mut dev_ctx: ID3D11DeviceContext = dev.GetImmediateContext().unwrap();
+        let dev_ctx: ID3D11DeviceContext = dev.GetImmediateContext().unwrap();
 
         let dev_ctx = dev_ctx;
         let mut sd = DXGI_SWAP_CHAIN_DESC::default();

--- a/src/hooks/dx12.rs
+++ b/src/hooks/dx12.rs
@@ -297,7 +297,7 @@ struct ImguiRenderer {
 impl ImguiRenderer {
     unsafe fn new(swap_chain: IDXGISwapChain3) -> Self {
         trace!("Initializing renderer");
-        let desc = DXGI_SWAP_CHAIN_DESC::default();
+        let mut desc = DXGI_SWAP_CHAIN_DESC::default();
         swap_chain.GetDesc(&mut desc).unwrap();
         let dev = swap_chain.GetDevice::<ID3D12Device>().unwrap();
 
@@ -439,7 +439,7 @@ impl ImguiRenderer {
         let frame_context = &mut self.frame_contexts[frame_contexts_idx];
 
         trace!("Rendering started");
-        let sd = DXGI_SWAP_CHAIN_DESC::default();
+        let mut sd = DXGI_SWAP_CHAIN_DESC::default();
         unsafe { swap_chain.GetDesc(&mut sd) }.unwrap();
         let mut rect: RECT = Default::default();
 

--- a/src/hooks/dx12.rs
+++ b/src/hooks/dx12.rs
@@ -542,7 +542,8 @@ impl ImguiRenderer {
 
         let barrier = barriers.into_iter().next().unwrap();
 
-        let _ = ManuallyDrop::into_inner(unsafe { barrier.Anonymous.Transition });
+        let ts = ManuallyDrop::into_inner(unsafe { barrier.Anonymous.Transition });
+        let _ = ManuallyDrop::into_inner(ts.pResource);
         trace!("Rendering done in {:?}", render_start.elapsed());
         None
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -213,22 +213,22 @@ pub mod lifecycle {
 
         use std::cell::OnceCell;
 
-        use windows::Win32::Foundation::HINSTANCE;
+        use windows::Win32::Foundation::HMODULE;
 
         use crate::hooks;
 
-        pub(super) static mut MODULE: OnceCell<HINSTANCE> = OnceCell::new();
+        pub(super) static mut MODULE: OnceCell<HMODULE> = OnceCell::new();
         pub(super) static mut HOOKS: OnceCell<Box<dyn hooks::Hooks>> = OnceCell::new();
 
         /// Please don't use me.
-        pub fn set_module(module: HINSTANCE) {
+        pub fn set_module(module: HMODULE) {
             unsafe {
                 MODULE.set(module).unwrap();
             }
         }
 
         /// Please don't use me.
-        pub fn get_module() -> HINSTANCE {
+        pub fn get_module() -> HMODULE {
             unsafe { *MODULE.get().unwrap() }
         }
 
@@ -243,7 +243,7 @@ pub use {imgui, tracing};
 
 /// Convenience reexports for the [macro](crate::hudhook).
 pub mod reexports {
-    pub use windows::Win32::Foundation::HINSTANCE;
+    pub use windows::Win32::Foundation::HMODULE;
     pub use windows::Win32::System::Console::{
         AllocConsole, FreeConsole, GetConsoleMode, GetStdHandle, SetConsoleMode, CONSOLE_MODE,
         ENABLE_VIRTUAL_TERMINAL_PROCESSING, STD_OUTPUT_HANDLE,
@@ -283,7 +283,7 @@ macro_rules! hudhook {
         /// Entry point created by the `hudhook` library.
         #[no_mangle]
         pub unsafe extern "stdcall" fn DllMain(
-            hmodule: HINSTANCE,
+            hmodule: HMODULE,
             reason: u32,
             _: *mut std::ffi::c_void,
         ) {

--- a/src/renderers/imgui_dx11/device_and_swapchain.rs
+++ b/src/renderers/imgui_dx11/device_and_swapchain.rs
@@ -36,7 +36,7 @@ impl DeviceAndSwapChain {
                 D3D_DRIVER_TYPE_HARDWARE,
                 None,
                 DEVICE_FLAGS,
-                None,
+                Some(&[]),
                 D3D11_SDK_VERSION,
                 Some(&DXGI_SWAP_CHAIN_DESC {
                     BufferCount: 1,

--- a/src/renderers/imgui_dx11/device_and_swapchain.rs
+++ b/src/renderers/imgui_dx11/device_and_swapchain.rs
@@ -82,7 +82,7 @@ impl DeviceAndSwapChain {
             dev.CreateRenderTargetView(&p_back_buffer, None, Some(&mut back_buffer))
                 .expect("CreateRenderTargetView");
 
-            dev_ctx.OMSetRenderTargets(Some(&[Some(back_buffer.unwrap().clone())]), None);
+            dev_ctx.OMSetRenderTargets(Some(&[Some(back_buffer.clone().unwrap())]), None);
 
             back_buffer
         };

--- a/src/renderers/imgui_dx11/render_engine.rs
+++ b/src/renderers/imgui_dx11/render_engine.rs
@@ -90,9 +90,9 @@ impl RenderEngine {
             dev_ctx.IASetVertexBuffers(
                 0,
                 1,
-                &Some(self.buffers.vtx_buffer()),
-                &(std::mem::size_of::<DrawVert>() as u32),
-                &0,
+                Some(&self.buffers.vtx_buffer()),
+                Some(std::mem::size_of::<DrawVert>() as *const u32),
+                Some(&0),
             );
             dev_ctx.IASetIndexBuffer(
                 &self.buffers.idx_buffer(),
@@ -104,8 +104,8 @@ impl RenderEngine {
                 0,
             );
             dev_ctx.IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
-            dev_ctx.VSSetConstantBuffers(0, &[Some(self.buffers.mtx_buffer())]);
-            dev_ctx.PSSetShaderResources(0, &[Some(self.texture.tex_view())]);
+            dev_ctx.VSSetConstantBuffers(0, Some(&[Some(self.buffers.mtx_buffer())]));
+            dev_ctx.PSSetShaderResources(0, Some(&[Some(self.texture.tex_view())]));
 
             let mut vtx_offset = 0usize;
             let mut idx_offset = 0usize;
@@ -117,12 +117,12 @@ impl RenderEngine {
                         DrawCmd::Elements { count, cmd_params } => {
                             trace!("Rendering {count} elements");
                             let [cx, cy, cw, ch] = cmd_params.clip_rect;
-                            dev_ctx.RSSetScissorRects(&[RECT {
+                            dev_ctx.RSSetScissorRects(Some(&[RECT {
                                 left: (cx - x) as i32,
                                 top: (cy - y) as i32,
                                 right: (cw - x) as i32,
                                 bottom: (ch - y) as i32,
-                            }]);
+                            }]));
 
                             // let srv = cmd_params.texture_id.id();
                             // We only load the font texture. This may not be correct.

--- a/src/renderers/imgui_dx11/shader_program.rs
+++ b/src/renderers/imgui_dx11/shader_program.rs
@@ -275,8 +275,8 @@ impl ShaderProgram {
     }
 
     pub(crate) unsafe fn set_state(&self, dasc: &DeviceAndSwapChain) {
-        dasc.dev_ctx().VSSetShader(&self.vtx_shader, None);
-        dasc.dev_ctx().PSSetShader(&self.pix_shader, None);
+        dasc.dev_ctx().VSSetShader(&self.vtx_shader, Some(&[]));
+        dasc.dev_ctx().PSSetShader(&self.pix_shader, Some(&[]));
         dasc.dev_ctx().IASetInputLayout(&self.layout);
         dasc.dev_ctx().PSSetSamplers(0, Some(&[Some(self.sampler.clone())]));
         dasc.dev_ctx().OMSetBlendState(&self.blend_state, Some(&[0f32; 4] as _), 0xFFFFFFFF);

--- a/src/renderers/imgui_dx11/state_backup.rs
+++ b/src/renderers/imgui_dx11/state_backup.rs
@@ -48,38 +48,43 @@ impl StateBackup {
             ..Default::default()
         };
         unsafe {
-            ctx.RSGetScissorRects(
-                &mut r.scissor_rects_count,
-                &mut r.scissor_rects as *mut _ as *mut _,
+            ctx.RSGetScissorRects(&mut r.scissor_rects_count, Some(&mut r.scissor_rects as _));
+            ctx.RSGetViewports(&mut r.viewports_count, Some(&mut r.viewports as _));
+            r.rasterizer_state = Some(ctx.RSGetState().unwrap());
+            ctx.OMGetBlendState(
+                Some(&mut r.blend_state),
+                Some(&mut r.blend_factor as _),
+                Some(&mut r.sample_mask),
             );
-            ctx.RSGetViewports(&mut r.viewports_count, &mut r.viewports as *mut _ as *mut _);
-            ctx.RSGetState(&mut r.rasterizer_state);
-            ctx.OMGetBlendState(&mut r.blend_state, &mut r.blend_factor as _, &mut r.sample_mask);
-            ctx.OMGetDepthStencilState(&mut r.depth_stencil_state, &mut r.stencil_ref);
-            ctx.PSGetShaderResources(0, &mut r.ps_shader_resource);
+            ctx.OMGetDepthStencilState(Some(&mut r.depth_stencil_state), Some(&mut r.stencil_ref));
+            ctx.PSGetShaderResources(0, Some(&mut r.ps_shader_resource));
             r.ps_instances_count = 256;
             r.vs_instances_count = 256;
             ctx.PSGetShader(
                 &mut r.pixel_shader,
-                &mut r.ps_instances as *mut _,
-                &mut r.ps_instances_count,
+                Some(&mut r.ps_instances as *mut _),
+                Some(&mut r.ps_instances_count),
             );
-            ctx.VSGetShader(&mut r.vertex_shader, &mut r.vs_instances, &mut r.vs_instances_count);
-            ctx.VSGetConstantBuffers(0, &mut r.vertex_constant_buffer);
-            ctx.IAGetPrimitiveTopology(&mut r.primitive_topology);
+            ctx.VSGetShader(
+                &mut r.vertex_shader,
+                Some(&mut r.vs_instances),
+                Some(&mut r.vs_instances_count),
+            );
+            ctx.VSGetConstantBuffers(0, Some(&mut r.vertex_constant_buffer));
+            r.primitive_topology = ctx.IAGetPrimitiveTopology();
             ctx.IAGetIndexBuffer(
-                &mut r.index_buffer,
-                &mut r.index_buffer_format,
-                &mut r.index_buffer_offset,
+                Some(&mut r.index_buffer),
+                Some(&mut r.index_buffer_format),
+                Some(&mut r.index_buffer_offset),
             );
             ctx.IAGetVertexBuffers(
                 0,
                 1,
-                &mut r.vertex_buffer,
-                &mut r.vertex_buffer_stride,
-                &mut r.vertex_buffer_offset,
+                Some(&mut r.vertex_buffer),
+                Some(&mut r.vertex_buffer_stride),
+                Some(&mut r.vertex_buffer_offset),
             );
-            ctx.IAGetInputLayout(&mut r.input_layout);
+            r.input_layout = Some(ctx.IAGetInputLayout().unwrap());
         }
 
         r
@@ -87,22 +92,22 @@ impl StateBackup {
 
     pub fn restore(self, ctx: ID3D11DeviceContext) {
         unsafe {
-            ctx.RSSetScissorRects(&self.scissor_rects);
-            ctx.RSSetViewports(&self.viewports);
+            ctx.RSSetScissorRects(Some(&self.scissor_rects));
+            ctx.RSSetViewports(Some(&self.viewports));
             ctx.RSSetState(self.rasterizer_state.as_ref());
             ctx.OMSetBlendState(
                 self.blend_state.as_ref(),
-                &self.blend_factor as _,
+                Some(&self.blend_factor as _),
                 self.sample_mask,
             );
             ctx.OMSetDepthStencilState(self.depth_stencil_state.as_ref(), self.stencil_ref);
-            ctx.PSSetShaderResources(0, &self.ps_shader_resource);
+            ctx.PSSetShaderResources(0, Some(&self.ps_shader_resource));
             // ctx.PSSetSamplers(0, &[self.ps_sampler]);
             if self.ps_instances.is_some() {
-                ctx.PSSetShader(self.pixel_shader.as_ref(), &[self.ps_instances]);
+                ctx.PSSetShader(self.pixel_shader.as_ref(), Some(&[self.ps_instances]));
             }
             if self.vs_instances.is_some() {
-                ctx.VSSetShader(self.vertex_shader.as_ref(), &[self.vs_instances]);
+                ctx.VSSetShader(self.vertex_shader.as_ref(), Some(&[self.vs_instances]));
             }
             ctx.IASetPrimitiveTopology(self.primitive_topology);
             ctx.IASetIndexBuffer(
@@ -113,9 +118,9 @@ impl StateBackup {
             ctx.IASetVertexBuffers(
                 0,
                 1,
-                &self.vertex_buffer,
-                &self.vertex_buffer_stride,
-                &self.vertex_buffer_offset,
+                Some(&self.vertex_buffer),
+                Some(&self.vertex_buffer_stride),
+                Some(&self.vertex_buffer_offset),
             );
             ctx.IASetInputLayout(self.input_layout.as_ref());
         }

--- a/src/renderers/imgui_dx11/state_backup.rs
+++ b/src/renderers/imgui_dx11/state_backup.rs
@@ -48,9 +48,17 @@ impl StateBackup {
             ..Default::default()
         };
         unsafe {
-            ctx.RSGetScissorRects(&mut r.scissor_rects_count, Some(&mut r.scissor_rects as _));
-            ctx.RSGetViewports(&mut r.viewports_count, Some(&mut r.viewports as _));
-            r.rasterizer_state = Some(ctx.RSGetState().unwrap());
+            ctx.RSGetScissorRects(
+                &mut r.scissor_rects_count,
+                Some(&mut r.scissor_rects as *mut _ as *mut _),
+            );
+            ctx.RSGetViewports(&mut r.viewports_count, Some(&mut r.viewports as *mut _ as *mut _));
+            if let Ok(state) = ctx.RSGetState() {
+                r.rasterizer_state = Some(state);
+            } else {
+                r.rasterizer_state = None;
+            }
+
             ctx.OMGetBlendState(
                 Some(&mut r.blend_state),
                 Some(&mut r.blend_factor as _),

--- a/src/renderers/imgui_dx11/texture.rs
+++ b/src/renderers/imgui_dx11/texture.rs
@@ -41,12 +41,12 @@ impl Texture {
                     BindFlags: D3D11_BIND_SHADER_RESOURCE,
                     CPUAccessFlags: D3D11_CPU_ACCESS_FLAG(0),
                     MiscFlags: D3D11_RESOURCE_MISC_FLAG(0),
-                },
+                } as *const _,
                 Some(&D3D11_SUBRESOURCE_DATA {
                     pSysMem: data.as_ptr() as _,
                     SysMemPitch: texture.width * 4,
                     SysMemSlicePitch: 0,
-                }),
+                } as *const _),
                 Some(&mut tex),
             )?
         };
@@ -62,7 +62,7 @@ impl Texture {
                         Anonymous: D3D11_SHADER_RESOURCE_VIEW_DESC_0 {
                             Texture2D: D3D11_TEX2D_SRV { MostDetailedMip: 0, MipLevels: 1 },
                         },
-                    }),
+                    } as *const _),
                     Some(&mut tex_view),
                 )
                 .unwrap()

--- a/src/renderers/imgui_dx11/texture.rs
+++ b/src/renderers/imgui_dx11/texture.rs
@@ -27,7 +27,7 @@ impl Texture {
         let texture = fonts.build_rgba32_texture();
         let data = texture.data.to_vec();
 
-        let tex = None;
+        let mut tex = None;
         unsafe {
             dasc.dev().CreateTexture2D(
                 &D3D11_TEXTURE2D_DESC {
@@ -51,22 +51,24 @@ impl Texture {
             )?
         };
 
-        let tex_view = None;
+        let mut tex_view = None;
         unsafe {
-            dasc.dev().CreateShaderResourceView(
-                &ID3D11Texture2D::cast::<ID3D11Resource>(&tex.unwrap()).unwrap(),
-                Some(&D3D11_SHADER_RESOURCE_VIEW_DESC {
-                    Format: DXGI_FORMAT_R8G8B8A8_UNORM,
-                    ViewDimension: D3D11_SRV_DIMENSION_TEXTURE2D,
-                    Anonymous: D3D11_SHADER_RESOURCE_VIEW_DESC_0 {
-                        Texture2D: D3D11_TEX2D_SRV { MostDetailedMip: 0, MipLevels: 1 },
-                    },
-                }),
-                Some(&mut tex_view),
-            )
+            dasc.dev()
+                .CreateShaderResourceView(
+                    &ID3D11Texture2D::cast::<ID3D11Resource>(&tex.as_ref().unwrap()).unwrap(),
+                    Some(&D3D11_SHADER_RESOURCE_VIEW_DESC {
+                        Format: DXGI_FORMAT_R8G8B8A8_UNORM,
+                        ViewDimension: D3D11_SRV_DIMENSION_TEXTURE2D,
+                        Anonymous: D3D11_SHADER_RESOURCE_VIEW_DESC_0 {
+                            Texture2D: D3D11_TEX2D_SRV { MostDetailedMip: 0, MipLevels: 1 },
+                        },
+                    }),
+                    Some(&mut tex_view),
+                )
+                .unwrap()
         };
 
-        let _font_sampler = None;
+        let mut _font_sampler = None;
         unsafe {
             dasc.dev().CreateSamplerState(
                 &D3D11_SAMPLER_DESC {

--- a/src/renderers/imgui_dx11/texture.rs
+++ b/src/renderers/imgui_dx11/texture.rs
@@ -1,12 +1,12 @@
 use tracing::trace;
-use windows::core::Error;
+use windows::core::{ComInterface, Error};
 use windows::Win32::Graphics::Direct3D::D3D11_SRV_DIMENSION_TEXTURE2D;
 use windows::Win32::Graphics::Direct3D11::{
-    ID3D11SamplerState, ID3D11ShaderResourceView, ID3D11Texture2D, D3D11_BIND_SHADER_RESOURCE,
-    D3D11_COMPARISON_ALWAYS, D3D11_CPU_ACCESS_FLAG, D3D11_FILTER_MIN_MAG_MIP_LINEAR,
-    D3D11_RESOURCE_MISC_FLAG, D3D11_SAMPLER_DESC, D3D11_SHADER_RESOURCE_VIEW_DESC,
-    D3D11_SHADER_RESOURCE_VIEW_DESC_0, D3D11_SUBRESOURCE_DATA, D3D11_TEX2D_SRV,
-    D3D11_TEXTURE2D_DESC, D3D11_TEXTURE_ADDRESS_WRAP, D3D11_USAGE_DEFAULT,
+    ID3D11Resource, ID3D11SamplerState, ID3D11ShaderResourceView, ID3D11Texture2D,
+    D3D11_BIND_SHADER_RESOURCE, D3D11_COMPARISON_ALWAYS, D3D11_CPU_ACCESS_FLAG,
+    D3D11_FILTER_MIN_MAG_MIP_LINEAR, D3D11_RESOURCE_MISC_FLAG, D3D11_SAMPLER_DESC,
+    D3D11_SHADER_RESOURCE_VIEW_DESC, D3D11_SHADER_RESOURCE_VIEW_DESC_0, D3D11_SUBRESOURCE_DATA,
+    D3D11_TEX2D_SRV, D3D11_TEXTURE2D_DESC, D3D11_TEXTURE_ADDRESS_WRAP, D3D11_USAGE_DEFAULT,
 };
 use windows::Win32::Graphics::Dxgi::Common::{DXGI_FORMAT_R8G8B8A8_UNORM, DXGI_SAMPLE_DESC};
 
@@ -27,7 +27,8 @@ impl Texture {
         let texture = fonts.build_rgba32_texture();
         let data = texture.data.to_vec();
 
-        let tex = unsafe {
+        let tex = None;
+        unsafe {
             dasc.dev().CreateTexture2D(
                 &D3D11_TEXTURE2D_DESC {
                     Width: texture.width as _,
@@ -40,44 +41,58 @@ impl Texture {
                     BindFlags: D3D11_BIND_SHADER_RESOURCE,
                     CPUAccessFlags: D3D11_CPU_ACCESS_FLAG(0),
                     MiscFlags: D3D11_RESOURCE_MISC_FLAG(0),
-                } as *const _,
-                &D3D11_SUBRESOURCE_DATA {
+                },
+                Some(&D3D11_SUBRESOURCE_DATA {
                     pSysMem: data.as_ptr() as _,
                     SysMemPitch: texture.width * 4,
                     SysMemSlicePitch: 0,
-                } as *const _,
+                }),
+                Some(&mut tex),
             )?
         };
 
-        let tex_view = unsafe {
-            dasc.dev().CreateShaderResourceView(&tex, &D3D11_SHADER_RESOURCE_VIEW_DESC {
-                Format: DXGI_FORMAT_R8G8B8A8_UNORM,
-                ViewDimension: D3D11_SRV_DIMENSION_TEXTURE2D,
-                Anonymous: D3D11_SHADER_RESOURCE_VIEW_DESC_0 {
-                    Texture2D: D3D11_TEX2D_SRV { MostDetailedMip: 0, MipLevels: 1 },
-                },
-            } as *const _)?
+        let tex_view = None;
+        unsafe {
+            dasc.dev().CreateShaderResourceView(
+                &ID3D11Texture2D::cast::<ID3D11Resource>(&tex.unwrap()).unwrap(),
+                Some(&D3D11_SHADER_RESOURCE_VIEW_DESC {
+                    Format: DXGI_FORMAT_R8G8B8A8_UNORM,
+                    ViewDimension: D3D11_SRV_DIMENSION_TEXTURE2D,
+                    Anonymous: D3D11_SHADER_RESOURCE_VIEW_DESC_0 {
+                        Texture2D: D3D11_TEX2D_SRV { MostDetailedMip: 0, MipLevels: 1 },
+                    },
+                }),
+                Some(&mut tex_view),
+            )
         };
 
-        let _font_sampler = unsafe {
-            dasc.dev().CreateSamplerState(&D3D11_SAMPLER_DESC {
-                Filter: D3D11_FILTER_MIN_MAG_MIP_LINEAR,
-                AddressU: D3D11_TEXTURE_ADDRESS_WRAP,
-                AddressV: D3D11_TEXTURE_ADDRESS_WRAP,
-                AddressW: D3D11_TEXTURE_ADDRESS_WRAP,
-                MipLODBias: 0.,
-                ComparisonFunc: D3D11_COMPARISON_ALWAYS,
-                MinLOD: 0.,
-                MaxLOD: 0.,
-                BorderColor: [0.; 4],
-                MaxAnisotropy: 0,
-            })?
+        let _font_sampler = None;
+        unsafe {
+            dasc.dev().CreateSamplerState(
+                &D3D11_SAMPLER_DESC {
+                    Filter: D3D11_FILTER_MIN_MAG_MIP_LINEAR,
+                    AddressU: D3D11_TEXTURE_ADDRESS_WRAP,
+                    AddressV: D3D11_TEXTURE_ADDRESS_WRAP,
+                    AddressW: D3D11_TEXTURE_ADDRESS_WRAP,
+                    MipLODBias: 0.,
+                    ComparisonFunc: D3D11_COMPARISON_ALWAYS,
+                    MinLOD: 0.,
+                    MaxLOD: 0.,
+                    BorderColor: [0.; 4],
+                    MaxAnisotropy: 0,
+                },
+                Some(&mut _font_sampler),
+            )?
         };
 
         fonts.tex_id = imgui::TextureId::from(&tex_view as *const _ as usize);
         trace!("Texture view: {:x} id: {:x}", &tex_view as *const _ as usize, fonts.tex_id.id());
 
-        Ok(Texture { _tex: tex, tex_view, _font_sampler })
+        Ok(Texture {
+            _tex: tex.unwrap(),
+            tex_view: tex_view.unwrap(),
+            _font_sampler: _font_sampler.unwrap(),
+        })
     }
 
     pub(crate) fn tex_view(&self) -> ID3D11ShaderResourceView {

--- a/src/renderers/imgui_opengl3.rs
+++ b/src/renderers/imgui_opengl3.rs
@@ -2,13 +2,13 @@ use std::ffi::{c_void, CString};
 
 use once_cell::sync::OnceCell;
 use windows::core::PCSTR;
-use windows::Win32::Foundation::{FARPROC, HINSTANCE};
+use windows::Win32::Foundation::{FARPROC, HMODULE};
 use windows::Win32::Graphics::OpenGL::wglGetProcAddress;
 use windows::Win32::System::LibraryLoader::{GetProcAddress, LoadLibraryA};
 
-static OPENGL3_LIB: OnceCell<HINSTANCE> = OnceCell::new();
+static OPENGL3_LIB: OnceCell<HMODULE> = OnceCell::new();
 
-unsafe fn get_opengl3_lib() -> HINSTANCE {
+unsafe fn get_opengl3_lib() -> HMODULE {
     let opengl3_cstring = CString::new("opengl32.dll").unwrap();
 
     LoadLibraryA(PCSTR(opengl3_cstring.as_ptr() as _)).unwrap()

--- a/tests/harness/dx11.rs
+++ b/tests/harness/dx11.rs
@@ -76,7 +76,7 @@ impl Dx11Harness {
                         HWND(0),
                         HMENU(0),
                         hinstance,
-                        null(),
+                        None,
                     )
                 };
 
@@ -91,9 +91,9 @@ impl Dx11Harness {
                         D3D_DRIVER_TYPE_HARDWARE,
                         None,
                         D3D11_CREATE_DEVICE_FLAG(0),
-                        &[D3D_FEATURE_LEVEL_11_0],
+                        Some(&[D3D_FEATURE_LEVEL_11_0]),
                         D3D11_SDK_VERSION,
-                        &DXGI_SWAP_CHAIN_DESC {
+                        Some(&DXGI_SWAP_CHAIN_DESC {
                             BufferDesc: DXGI_MODE_DESC {
                                 Width: 800,
                                 Height: 600,
@@ -108,11 +108,11 @@ impl Dx11Harness {
                             SwapEffect: DXGI_SWAP_EFFECT_DISCARD,
                             SampleDesc: DXGI_SAMPLE_DESC { Count: 1, Quality: 0 },
                             ..Default::default()
-                        },
-                        &mut p_swap_chain,
-                        &mut p_device,
-                        null_mut(),
-                        &mut p_context,
+                        }),
+                        Some(&mut p_swap_chain),
+                        Some(&mut p_device),
+                        None,
+                        Some(&mut p_context),
                     )
                     .unwrap()
                 };
@@ -123,11 +123,11 @@ impl Dx11Harness {
                         for i in 0..diq.GetNumStoredMessages(DXGI_DEBUG_ALL) {
                             eprintln!("Debug Message {i}");
                             let mut msg_len: usize = 0;
-                            diq.GetMessage(DXGI_DEBUG_ALL, i, null_mut(), &mut msg_len as _)
-                                .unwrap();
+                            diq.GetMessage(DXGI_DEBUG_ALL, i, None, &mut msg_len as _).unwrap();
                             let diqm = vec![0u8; msg_len];
                             let pdiqm = diqm.as_ptr() as *mut DXGI_INFO_QUEUE_MESSAGE;
-                            diq.GetMessage(DXGI_DEBUG_ALL, i, pdiqm, &mut msg_len as _).unwrap();
+                            diq.GetMessage(DXGI_DEBUG_ALL, i, Some(pdiqm), &mut msg_len as _)
+                                .unwrap();
                             let diqm = pdiqm.as_ref().unwrap();
                             eprintln!(
                                 "{}",

--- a/tests/harness/dx11.rs
+++ b/tests/harness/dx11.rs
@@ -1,6 +1,6 @@
 use std::ffi::CString;
 use std::mem::MaybeUninit;
-use std::ptr::{null, null_mut};
+use std::ptr::null_mut;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::thread::{self, JoinHandle};

--- a/tests/harness/dx12.rs
+++ b/tests/harness/dx12.rs
@@ -1,12 +1,12 @@
 use std::ffi::CString;
 use std::mem::MaybeUninit;
-use std::ptr::{null, null_mut};
+use std::ptr::null;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::thread::{self, JoinHandle};
 
 use tracing::trace;
-use windows::core::{Interface, PCSTR};
+use windows::core::{ComInterface, PCSTR};
 use windows::Win32::Foundation::{BOOL, HWND, LPARAM, LRESULT, RECT, WPARAM};
 use windows::Win32::Graphics::Direct3D::D3D_FEATURE_LEVEL_11_0;
 use windows::Win32::Graphics::Direct3D12::{
@@ -83,7 +83,7 @@ impl Dx12Harness {
                         HWND::default(),  // hWndParent
                         HMENU::default(), // hMenu
                         hinstance,        // hInstance
-                        null(),
+                        None,
                     )
                 }; // lpParam
 
@@ -141,8 +141,10 @@ impl Dx12Harness {
                     )
                 }
                 .unwrap();
-                let swap_chain: IDXGISwapChain3 = swap_chain.unwrap().cast().unwrap();
-                let desc = unsafe { swap_chain.GetDesc().unwrap() };
+                let swap_chain: IDXGISwapChain3 =
+                    IDXGISwapChain::cast::<IDXGISwapChain3>(&swap_chain.unwrap()).unwrap();
+                let mut desc = DXGI_SWAP_CHAIN_DESC::default();
+                unsafe { swap_chain.GetDesc(&mut desc).unwrap() };
 
                 let _renderer_heap: ID3D12DescriptorHeap = unsafe {
                     dev.CreateDescriptorHeap(&D3D12_DESCRIPTOR_HEAP_DESC {
@@ -174,7 +176,7 @@ impl Dx12Harness {
                         let rtv_handle = D3D12_CPU_DESCRIPTOR_HANDLE {
                             ptr: rtv_start.ptr + (i * rtv_heap_inc_size) as usize,
                         };
-                        dev.CreateRenderTargetView(&buf, null(), rtv_handle);
+                        dev.CreateRenderTargetView(&buf, None, rtv_handle);
                     }
                 }
 
@@ -185,11 +187,11 @@ impl Dx12Harness {
                     unsafe {
                         for i in 0..diq.GetNumStoredMessages(DXGI_DEBUG_ALL) {
                             let mut msg_len: usize = 0;
-                            diq.GetMessage(DXGI_DEBUG_ALL, i, null_mut(), &mut msg_len as _)
-                                .unwrap();
+                            diq.GetMessage(DXGI_DEBUG_ALL, i, None, &mut msg_len as _).unwrap();
                             let diqm = vec![0u8; msg_len];
                             let pdiqm = diqm.as_ptr() as *mut DXGI_INFO_QUEUE_MESSAGE;
-                            diq.GetMessage(DXGI_DEBUG_ALL, i, pdiqm, &mut msg_len as _).unwrap();
+                            diq.GetMessage(DXGI_DEBUG_ALL, i, Some(pdiqm), &mut msg_len as _)
+                                .unwrap();
                             let diqm = pdiqm.as_ref().unwrap();
                             println!(
                                 "{}",

--- a/tests/harness/opengl3.rs
+++ b/tests/harness/opengl3.rs
@@ -69,7 +69,7 @@ impl Opengl3Harness {
                         HWND::default(),  // hWndParent
                         HMENU::default(), // hMenu
                         hinstance,        // hInstance
-                        null(),
+                        None,
                     )
                 }; // lpParam
 


### PR DESCRIPTION
Hope this is alright, not sure if you wanted to do it yourself @veeenu but I need a bump for some DirectX stuff on my end.

Everything works apart from DX11 and I do at the moment not have much of a clue what I did wrong. Still looking into it but I'd appreciate a quick lookover on it!

``Message: panicked at 'called `Result::unwrap()` on an `Err` value: Error { code: HRESULT(0x00000000), message: "The operation completed successfully." }', C:\Users\Godnoken\Desktop\Skrivbord\Programming\hudhook\src\renderers\imgui_dx11\state_backup.rs:95:58``

This is the error I'm getting. Tried fixing that in the last commit (got it from `ctx.RSGetState()` before, and now `ctx.IAGetInputLayout()`).
I assume that these two functions always returned `None` but that it is only now crashing because there wasn't any error handling implemented into them in previous versions of windows-rs.

Either way, I implemented the same error handling for the InputLayout but there is still some obscure crash happening and I don't get any more crash messages..