### PR TITLE
Remove `HookableBackend` trait

### DIFF
--- a/src/hooks/common.rs
+++ b/src/hooks/common.rs
@@ -7,10 +7,6 @@ use windows::Win32::Foundation::{HWND, LPARAM, LRESULT, WPARAM};
 use windows::Win32::UI::Input::KeyboardAndMouse::*;
 use windows::Win32::UI::WindowsAndMessaging::{WHEEL_DELTA, WM_XBUTTONDBLCLK, XBUTTON1, *};
 
-use super::dx11::ImguiDx11Hooks;
-use super::dx12::ImguiDx12Hooks;
-use super::dx9::ImguiDx9Hooks;
-use super::opengl3::ImguiOpenGl3Hooks;
 use super::{get_wheel_delta_wparam, hiword, loword, Hooks};
 
 pub(crate) type WndProcType =
@@ -179,34 +175,6 @@ pub struct ImguiRenderLoopFlags {
     pub focused: bool,
 }
 
-pub trait HookableBackend: Hooks {
-    fn from_struct<T: ImguiRenderLoop + Send + Sync + Sized + 'static>(t: T) -> Self;
-}
-
-impl HookableBackend for ImguiDx9Hooks {
-    fn from_struct<T: ImguiRenderLoop + Send + Sync + Sized + 'static>(t: T) -> Self {
-        unsafe { ImguiDx9Hooks::new(t) }
-    }
-}
-
-impl HookableBackend for ImguiDx11Hooks {
-    fn from_struct<T: ImguiRenderLoop + Send + Sync + Sized + 'static>(t: T) -> Self {
-        unsafe { ImguiDx11Hooks::new(t) }
-    }
-}
-
-impl HookableBackend for ImguiDx12Hooks {
-    fn from_struct<T: ImguiRenderLoop + Send + Sync + Sized + 'static>(t: T) -> Self {
-        unsafe { ImguiDx12Hooks::new(t) }
-    }
-}
-
-impl HookableBackend for ImguiOpenGl3Hooks {
-    fn from_struct<T: ImguiRenderLoop + Send + Sync + Sized + 'static>(t: T) -> Self {
-        unsafe { ImguiOpenGl3Hooks::new(t) }
-    }
-}
-
 /// Implement your `imgui` rendering logic via this trait.
 pub trait ImguiRenderLoop {
     /// Called once at the first occurrence of the hook. Implement this to
@@ -223,10 +191,10 @@ pub trait ImguiRenderLoop {
 
     fn into_hook<T>(self) -> Box<T>
     where
-        T: HookableBackend,
+        T: Hooks,
         Self: Send + Sync + Sized + 'static,
     {
-        Box::<T>::new(HookableBackend::from_struct(self))
+        T::from_render_loop(self)
     }
 }
 

--- a/src/hooks/dx11.rs
+++ b/src/hooks/dx11.rs
@@ -382,6 +382,14 @@ impl ImguiDx11Hooks {
 }
 
 impl Hooks for ImguiDx11Hooks {
+    fn from_render_loop<T>(t: T) -> Box<Self>
+    where
+        Self: Sized,
+        T: ImguiRenderLoop + Send + Sync + 'static,
+    {
+        Box::new(unsafe { ImguiDx11Hooks::new(t) })
+    }
+
     unsafe fn hook(&self) {
         self.0.apply();
     }

--- a/src/hooks/dx12.rs
+++ b/src/hooks/dx12.rs
@@ -793,6 +793,14 @@ impl ImguiDx12Hooks {
 }
 
 impl Hooks for ImguiDx12Hooks {
+    fn from_render_loop<T>(t: T) -> Box<Self>
+    where
+        Self: Sized,
+        T: ImguiRenderLoop + Send + Sync + 'static,
+    {
+        Box::new(unsafe { ImguiDx12Hooks::new(t) })
+    }
+
     unsafe fn hook(&self) {
         self.0.apply();
     }

--- a/src/hooks/dx9.rs
+++ b/src/hooks/dx9.rs
@@ -280,6 +280,14 @@ impl ImguiDx9Hooks {
 }
 
 impl Hooks for ImguiDx9Hooks {
+    fn from_render_loop<T>(t: T) -> Box<Self>
+    where
+        Self: Sized,
+        T: ImguiRenderLoop + Send + Sync + 'static,
+    {
+        Box::new(unsafe { ImguiDx9Hooks::new(t) })
+    }
+
     unsafe fn hook(&self) {
         self.0.apply();
     }

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -15,6 +15,11 @@ pub use common::{ImguiRenderLoop, ImguiRenderLoopFlags};
 
 /// Generic trait for platform-specific hooks.
 pub trait Hooks {
+    fn from_render_loop<T>(t: T) -> Box<Self>
+    where
+        Self: Sized,
+        T: ImguiRenderLoop + Send + Sync + 'static;
+
     /// Find the hook target functions addresses, initialize the data, create
     /// and enable the hooks.
     ///

--- a/src/hooks/opengl3.rs
+++ b/src/hooks/opengl3.rs
@@ -298,6 +298,14 @@ impl ImguiOpenGl3Hooks {
 }
 
 impl Hooks for ImguiOpenGl3Hooks {
+    fn from_render_loop<T>(t: T) -> Box<Self>
+    where
+        Self: Sized,
+        T: ImguiRenderLoop + Send + Sync + 'static,
+    {
+        Box::new(unsafe { ImguiOpenGl3Hooks::new(t) })
+    }
+
     unsafe fn hook(&self) {
         self.0.apply();
     }


### PR DESCRIPTION
This PR adds a contract to the `Hooks` trait. 

This allows third party backends to be implemented by just supplying the constructor around an `ImguiRenderLoop` object.