### PR TITLE
Simplify dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,6 @@ crate-type = ["bin"]
 [dependencies]
 imgui = "0.11.0"
 imgui-opengl = "0.1.0"
-memoffset = "0.6.5"
 once_cell = "1.8.0"
 parking_lot = "0.11.2"
 widestring = "1.0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ crate-type = ["bin"]
 [dependencies]
 imgui = "0.11.0"
 imgui-opengl = "0.1.0"
-once_cell = "1.8.0"
+# once_cell = "1.8.0"
 parking_lot = "0.11.2"
 widestring = "1.0.1"
 windows = { version = "0.39.0", features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,6 @@ crate-type = ["bin"]
 [dependencies]
 imgui = "0.11.0"
 imgui-opengl = "0.1.0"
-# once_cell = "1.8.0"
 parking_lot = "0.11.2"
 widestring = "1.0.1"
 windows = { version = "0.39.0", features = [

--- a/src/hooks/dx11.rs
+++ b/src/hooks/dx11.rs
@@ -1,9 +1,9 @@
 use std::ffi::c_void;
 use std::mem;
 use std::ptr::null_mut;
+use std::sync::OnceLock;
 
 use imgui::Context;
-use once_cell::sync::OnceCell;
 use parking_lot::Mutex;
 use tracing::{debug, error, trace};
 use windows::core::{Interface, HRESULT};
@@ -66,15 +66,15 @@ trait Renderer {
 // Global singletons
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-static TRAMPOLINE: OnceCell<(DXGISwapChainPresentType, DXGISwapChainResizeBuffersType)> =
-    OnceCell::new();
+static TRAMPOLINE: OnceLock<(DXGISwapChainPresentType, DXGISwapChainResizeBuffersType)> =
+    OnceLock::new();
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // Hook entry points
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-static mut IMGUI_RENDER_LOOP: OnceCell<Box<dyn ImguiRenderLoop + Send + Sync>> = OnceCell::new();
-static mut IMGUI_RENDERER: OnceCell<Mutex<Box<ImguiRenderer>>> = OnceCell::new();
+static mut IMGUI_RENDER_LOOP: OnceLock<Box<dyn ImguiRenderLoop + Send + Sync>> = OnceLock::new();
+static mut IMGUI_RENDERER: OnceLock<Mutex<Box<ImguiRenderer>>> = OnceLock::new();
 
 unsafe extern "system" fn imgui_dxgi_swap_chain_present_impl(
     p_this: IDXGISwapChain,

--- a/src/hooks/dx12.rs
+++ b/src/hooks/dx12.rs
@@ -3,11 +3,11 @@ use std::ffi::c_void;
 use std::mem::{self, ManuallyDrop};
 use std::ptr::{null, null_mut};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::OnceLock;
 use std::thread;
 use std::time::{Duration, Instant};
 
 use imgui::Context;
-use once_cell::sync::OnceCell;
 use parking_lot::Mutex;
 use tracing::{debug, error, info, trace};
 use widestring::{u16cstr, U16CStr};
@@ -74,11 +74,11 @@ trait Renderer {
 // Global singletons
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-static TRAMPOLINE: OnceCell<(
+static TRAMPOLINE: OnceLock<(
     DXGISwapChainPresentType,
     ExecuteCommandListsType,
     ResizeBuffersType,
-)> = OnceCell::new();
+)> = OnceLock::new();
 
 const COMMAND_ALLOCATOR_NAMES: [&U16CStr; 8] = [
     u16cstr!("hudhook Command allocator #0"),
@@ -120,9 +120,9 @@ unsafe fn print_dxgi_debug_messages() {
 // Hook entry points
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-static mut IMGUI_RENDER_LOOP: OnceCell<Box<dyn ImguiRenderLoop + Send + Sync>> = OnceCell::new();
-static mut IMGUI_RENDERER: OnceCell<Mutex<Box<ImguiRenderer>>> = OnceCell::new();
-static mut COMMAND_QUEUE_GUARD: OnceCell<()> = OnceCell::new();
+static mut IMGUI_RENDER_LOOP: OnceLock<Box<dyn ImguiRenderLoop + Send + Sync>> = OnceLock::new();
+static mut IMGUI_RENDERER: OnceLock<Mutex<Box<ImguiRenderer>>> = OnceLock::new();
+static mut COMMAND_QUEUE_GUARD: OnceLock<()> = OnceLock::new();
 static DXGI_DEBUG_ENABLED: AtomicBool = AtomicBool::new(false);
 
 static CQECL_RUNNING: Fence = Fence::new();

--- a/src/hooks/dx9.rs
+++ b/src/hooks/dx9.rs
@@ -1,7 +1,7 @@
 use std::mem;
+use std::sync::OnceLock;
 
 use imgui::Context;
-use once_cell::sync::OnceCell;
 use parking_lot::Mutex;
 use tracing::{debug, trace};
 use windows::core::{Interface, HRESULT};
@@ -159,9 +159,9 @@ unsafe extern "system" fn imgui_dx9_present_impl(
     trampoline_present(this, psourcerect, pdestrect, hdestwindowoverride, pdirtyregion)
 }
 
-static mut IMGUI_RENDER_LOOP: OnceCell<Box<dyn ImguiRenderLoop + Send + Sync>> = OnceCell::new();
-static mut IMGUI_RENDERER: OnceCell<Mutex<Box<ImguiRenderer>>> = OnceCell::new();
-static TRAMPOLINE: OnceCell<(Dx9EndSceneFn, Dx9PresentFn, Dx9ResetFn)> = OnceCell::new();
+static mut IMGUI_RENDER_LOOP: OnceLock<Box<dyn ImguiRenderLoop + Send + Sync>> = OnceLock::new();
+static mut IMGUI_RENDERER: OnceLock<Mutex<Box<ImguiRenderer>>> = OnceLock::new();
+static TRAMPOLINE: OnceLock<(Dx9EndSceneFn, Dx9PresentFn, Dx9ResetFn)> = OnceLock::new();
 
 struct ImguiRenderer {
     ctx: Context,

--- a/src/hooks/opengl3.rs
+++ b/src/hooks/opengl3.rs
@@ -1,8 +1,8 @@
 use std::ffi::CString;
+use std::sync::OnceLock;
 use std::time::Instant;
 
 use imgui::Context;
-use once_cell::sync::OnceCell;
 use parking_lot::Mutex;
 use tracing::{debug, trace};
 use windows::core::PCSTR;
@@ -158,9 +158,9 @@ unsafe fn reset(hdc: HDC) {
     }
 }
 
-static mut IMGUI_RENDER_LOOP: OnceCell<Box<dyn ImguiRenderLoop + Send + Sync>> = OnceCell::new();
+static mut IMGUI_RENDER_LOOP: OnceLock<Box<dyn ImguiRenderLoop + Send + Sync>> = OnceLock::new();
 static mut IMGUI_RENDERER: Option<Mutex<Box<ImguiRenderer>>> = None;
-static TRAMPOLINE: OnceCell<OpenGl32wglSwapBuffers> = OnceCell::new();
+static TRAMPOLINE: OnceLock<OpenGl32wglSwapBuffers> = OnceLock::new();
 
 struct ImguiRenderer {
     ctx: Context,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,7 @@
 #![feature(lazy_cell)]
 #![feature(offset_of)]
+#![feature(once_cell_try)]
+
 //! # hudhook
 //!
 //! This library implements a mechanism for hooking into the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![feature(lazy_cell)]
+#![feature(offset_of)]
 //! # hudhook
 //!
 //! This library implements a mechanism for hooking into the

--- a/src/renderers/imgui_dx12.rs
+++ b/src/renderers/imgui_dx12.rs
@@ -1,11 +1,10 @@
 use std::ffi::c_void;
-use std::mem::{size_of, ManuallyDrop};
+use std::mem::{offset_of, size_of, ManuallyDrop};
 use std::ptr::{null, null_mut};
 
 pub use imgui;
 use imgui::internal::RawWrapper;
 use imgui::{BackendFlags, DrawCmd, DrawData, DrawIdx, DrawVert, TextureId};
-use memoffset::offset_of;
 use tracing::{error, trace};
 use widestring::u16cstr;
 use windows::core::{Result, PCSTR, PCWSTR};
@@ -461,9 +460,9 @@ impl RenderEngine {
         let mut pix_shader: Option<ID3DBlob> = None;
 
         let vs = r#"
-                cbuffer vertexBuffer : register(b0) 
+                cbuffer vertexBuffer : register(b0)
                 {
-                  float4x4 ProjectionMatrix; 
+                  float4x4 ProjectionMatrix;
                 };
                 struct VS_INPUT
                 {
@@ -471,14 +470,14 @@ impl RenderEngine {
                   float4 col : COLOR0;
                   float2 uv  : TEXCOORD0;
                 };
-                
+
                 struct PS_INPUT
                 {
                   float4 pos : SV_POSITION;
                   float4 col : COLOR0;
                   float2 uv  : TEXCOORD0;
                 };
-                
+
                 PS_INPUT main(VS_INPUT input)
                 {
                   PS_INPUT output;
@@ -514,11 +513,11 @@ impl RenderEngine {
                 };
                 SamplerState sampler0 : register(s0);
                 Texture2D texture0 : register(t0);
-                
+
                 float4 main(PS_INPUT input) : SV_Target
                 {
-                  float4 out_col = input.col * texture0.Sample(sampler0, input.uv); 
-                  return out_col; 
+                  float4 out_col = input.col * texture0.Sample(sampler0, input.uv);
+                  return out_col;
                 }"#;
 
         unsafe {

--- a/src/renderers/imgui_opengl3.rs
+++ b/src/renderers/imgui_opengl3.rs
@@ -1,12 +1,12 @@
 use std::ffi::{c_void, CString};
+use std::sync::OnceLock;
 
-use once_cell::sync::OnceCell;
 use windows::core::PCSTR;
 use windows::Win32::Foundation::{FARPROC, HINSTANCE};
 use windows::Win32::Graphics::OpenGL::wglGetProcAddress;
 use windows::Win32::System::LibraryLoader::{GetProcAddress, LoadLibraryA};
 
-static OPENGL3_LIB: OnceCell<HINSTANCE> = OnceCell::new();
+static OPENGL3_LIB: OnceLock<HINSTANCE> = OnceLock::new();
 
 unsafe fn get_opengl3_lib() -> HINSTANCE {
     let opengl3_cstring = CString::new("opengl32.dll").unwrap();


### PR DESCRIPTION
Removed the "once_cell" dependency and replaced it with #![feature(once_cell_try)]
Removed the "memoffset" dependency and replaced it with #![feature(offset_of)]

#[stable(feature = "once_cell", since = "1.70.0")]
#[unstable(feature = "offset_of", issue = "106655")]
https://github.com/rust-lang/rust/issues/106655

Did a simple test
1.71.0-nightly
once_cell = "1.8.0"

Debug
std::sync::OnceLock time: 1.8730884s
once_cell::sync::OnceCell time: 4.1763288s

Release
std::sync::OnceLock time: 47.0772ms
once_cell::sync::OnceCell time: 47.0337ms