### PR TITLE
Simplify dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,6 @@ crate-type = ["bin"]
 imgui = "0.11.0"
 imgui-opengl = "0.1.0"
 parking_lot = "0.11.2"
-widestring = "1.0.1"
 windows = { version = "0.39.0", features = [
   "Win32_Devices_HumanInterfaceDevice",
   "Win32_Foundation",

--- a/examples/dx11_host.rs
+++ b/examples/dx11_host.rs
@@ -6,7 +6,7 @@
 use std::mem::MaybeUninit;
 use std::ptr::{null, null_mut};
 
-use windows::core::{PCSTR, PCWSTR};
+use windows::core::{HSTRING, PCSTR, PCWSTR};
 use windows::Win32::Foundation::{HWND, LPARAM, LRESULT, WPARAM};
 use windows::Win32::Graphics::Dxgi::{
     DXGIGetDebugInterface1, IDXGIInfoQueue, DXGI_DEBUG_ALL, DXGI_INFO_QUEUE_MESSAGE,
@@ -64,11 +64,7 @@ pub fn main(_argc: i32, _argv: *const *const u8) {
     println!("{:?}", dll_path.canonicalize());
     unsafe {
         LoadLibraryExW(
-            PCWSTR(
-                widestring::WideCString::from_os_str(dll_path.canonicalize().unwrap().as_os_str())
-                    .unwrap()
-                    .as_ptr(),
-            ),
+            PCWSTR(HSTRING::from(dll_path.canonicalize().unwrap().as_os_str()).as_ptr()),
             None,
             LOAD_LIBRARY_FLAGS(0),
         )

--- a/src/hooks/dx12.rs
+++ b/src/hooks/dx12.rs
@@ -10,8 +10,7 @@ use std::time::{Duration, Instant};
 use imgui::Context;
 use parking_lot::Mutex;
 use tracing::{debug, error, info, trace};
-use widestring::{u16cstr, U16CStr};
-use windows::core::{Interface, HRESULT, PCWSTR};
+use windows::core::{Interface, HRESULT, HSTRING, PCWSTR};
 use windows::w;
 use windows::Win32::Foundation::{
     GetLastError, BOOL, HANDLE, HWND, LPARAM, LRESULT, POINT, RECT, WPARAM,
@@ -80,15 +79,15 @@ static TRAMPOLINE: OnceLock<(
     ResizeBuffersType,
 )> = OnceLock::new();
 
-const COMMAND_ALLOCATOR_NAMES: [&U16CStr; 8] = [
-    u16cstr!("hudhook Command allocator #0"),
-    u16cstr!("hudhook Command allocator #1"),
-    u16cstr!("hudhook Command allocator #2"),
-    u16cstr!("hudhook Command allocator #3"),
-    u16cstr!("hudhook Command allocator #4"),
-    u16cstr!("hudhook Command allocator #5"),
-    u16cstr!("hudhook Command allocator #6"),
-    u16cstr!("hudhook Command allocator #7"),
+const COMMAND_ALLOCATOR_NAMES: [&HSTRING; 8] = [
+    w!("hudhook Command allocator #0"),
+    w!("hudhook Command allocator #1"),
+    w!("hudhook Command allocator #2"),
+    w!("hudhook Command allocator #3"),
+    w!("hudhook Command allocator #4"),
+    w!("hudhook Command allocator #5"),
+    w!("hudhook Command allocator #6"),
+    w!("hudhook Command allocator #7"),
 ];
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -317,7 +316,7 @@ impl ImguiRenderer {
         command_list.Close().unwrap();
 
         command_list
-            .SetName(PCWSTR(u16cstr!("hudhook Command List").as_ptr()))
+            .SetName(PCWSTR(w!("hudhook Command List").as_ptr()))
             .expect("Couldn't set command list name");
 
         let rtv_heap: ID3D12DescriptorHeap = dev

--- a/src/renderers/imgui_dx12.rs
+++ b/src/renderers/imgui_dx12.rs
@@ -6,8 +6,8 @@ pub use imgui;
 use imgui::internal::RawWrapper;
 use imgui::{BackendFlags, DrawCmd, DrawData, DrawIdx, DrawVert, TextureId};
 use tracing::{error, trace};
-use widestring::u16cstr;
 use windows::core::{Result, PCSTR, PCWSTR};
+use windows::w;
 use windows::Win32::Foundation::{CloseHandle, BOOL, RECT};
 use windows::Win32::Graphics::Direct3D::Fxc::D3DCompile;
 use windows::Win32::Graphics::Direct3D::{
@@ -736,17 +736,14 @@ impl RenderEngine {
         }
         .unwrap();
 
-        unsafe {
-            cmd_queue.SetName(PCWSTR(u16cstr!("hudhook font texture Command Queue").as_ptr()))
-        }
-        .unwrap();
+        unsafe { cmd_queue.SetName(PCWSTR(w!("hudhook font texture Command Queue").as_ptr())) }
+            .unwrap();
 
         let cmd_allocator: ID3D12CommandAllocator =
             unsafe { self.dev.CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT) }.unwrap();
 
         unsafe {
-            cmd_allocator
-                .SetName(PCWSTR(u16cstr!("hudhook font texture Command Allocator").as_ptr()))
+            cmd_allocator.SetName(PCWSTR(w!("hudhook font texture Command Allocator").as_ptr()))
         }
         .unwrap();
 
@@ -755,7 +752,7 @@ impl RenderEngine {
         }
         .unwrap();
 
-        unsafe { cmd_list.SetName(PCWSTR(u16cstr!("hudhook font texture Command List").as_ptr())) }
+        unsafe { cmd_list.SetName(PCWSTR(w!("hudhook font texture Command List").as_ptr())) }
             .unwrap();
 
         let src_location = D3D12_TEXTURE_COPY_LOCATION {


### PR DESCRIPTION
Removed the "widestring" dependency

Test passed
```rust
    // Ok
    // let process = hudhook::inject::Process::by_name("re8.exe").unwrap();

    // Ok
    // let process = hudhook::inject::Process::by_name("re8.exe\0 I don't care about this stuff").unwrap();

    // Ok
    // let process = hudhook::inject::Process::by_title("Resident Evil Village").unwrap();

    // Ok
    let process =
        hudhook::inject::Process::by_title("Resident Evil Village\0 I don't care about this stuff")
            .unwrap();

    // Ok
    process.inject("d3d11.dll".into()).unwrap();
```