### PR TITLE
Bump dependencies and add feature crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,9 +67,9 @@ path = "examples/renderers/dx12.rs"
 crate-type = ["bin"]
 
 [dependencies]
-imgui = "0.11.0"
-imgui-opengl = "0.1.0"
-parking_lot = "0.11.2"
+imgui = "0.11"
+imgui-opengl = "0.1"
+parking_lot = "0.12"
 windows = { version = "0.39.0", features = [
   "Win32_Devices_HumanInterfaceDevice",
   "Win32_Foundation",
@@ -97,6 +97,8 @@ windows = { version = "0.39.0", features = [
   "Win32_UI_WindowsAndMessaging",
 ] }
 tracing = { version = "0.1", features = ["log"] }
+memoffset = "0.9.0"
+once_cell = "1.18.0"
 
 [dev-dependencies]
 tracing-subscriber = "0.3"

--- a/src/hooks/dx12.rs
+++ b/src/hooks/dx12.rs
@@ -3,11 +3,11 @@ use std::ffi::c_void;
 use std::mem::{self, ManuallyDrop};
 use std::ptr::{null, null_mut};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::OnceLock;
 use std::thread;
 use std::time::{Duration, Instant};
 
 use imgui::Context;
+use once_cell::sync::OnceCell;
 use parking_lot::Mutex;
 use tracing::{debug, error, info, trace};
 use windows::core::{Interface, HRESULT, HSTRING, PCWSTR};
@@ -73,11 +73,11 @@ trait Renderer {
 // Global singletons
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-static TRAMPOLINE: OnceLock<(
+static TRAMPOLINE: OnceCell<(
     DXGISwapChainPresentType,
     ExecuteCommandListsType,
     ResizeBuffersType,
-)> = OnceLock::new();
+)> = OnceCell::new();
 
 const COMMAND_ALLOCATOR_NAMES: [&HSTRING; 8] = [
     w!("hudhook Command allocator #0"),
@@ -119,9 +119,9 @@ unsafe fn print_dxgi_debug_messages() {
 // Hook entry points
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-static mut IMGUI_RENDER_LOOP: OnceLock<Box<dyn ImguiRenderLoop + Send + Sync>> = OnceLock::new();
-static mut IMGUI_RENDERER: OnceLock<Mutex<Box<ImguiRenderer>>> = OnceLock::new();
-static mut COMMAND_QUEUE_GUARD: OnceLock<()> = OnceLock::new();
+static mut IMGUI_RENDER_LOOP: OnceCell<Box<dyn ImguiRenderLoop + Send + Sync>> = OnceCell::new();
+static mut IMGUI_RENDERER: OnceCell<Mutex<Box<ImguiRenderer>>> = OnceCell::new();
+static mut COMMAND_QUEUE_GUARD: OnceCell<()> = OnceCell::new();
 static DXGI_DEBUG_ENABLED: AtomicBool = AtomicBool::new(false);
 
 static CQECL_RUNNING: Fence = Fence::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,3 @@
-#![feature(lazy_cell)]
-#![feature(offset_of)]
-#![feature(once_cell_try)]
-
 //! # hudhook
 //!
 //! This library implements a mechanism for hooking into the

--- a/src/renderers/imgui_dx12.rs
+++ b/src/renderers/imgui_dx12.rs
@@ -1,10 +1,11 @@
 use std::ffi::c_void;
-use std::mem::{offset_of, size_of, ManuallyDrop};
+use std::mem::{size_of, ManuallyDrop};
 use std::ptr::{null, null_mut};
 
 pub use imgui;
 use imgui::internal::RawWrapper;
 use imgui::{BackendFlags, DrawCmd, DrawData, DrawIdx, DrawVert, TextureId};
+use memoffset::offset_of;
 use tracing::{error, trace};
 use windows::core::{Result, PCSTR, PCWSTR};
 use windows::w;


### PR DESCRIPTION
This PR removes nightly features, temporarily replacing them with crates, thus dropping the `nightly` requirement.

Eventually, we want to remove these dependencies in favor of `std`, but this will suffice for now.

Closes #106.