### PR TITLE
Add wnd proc hook to ImguiRenderLoop

### DIFF
--- a/src/hooks/common/mod.rs
+++ b/src/hooks/common/mod.rs
@@ -22,8 +22,12 @@ pub trait ImguiRenderLoop {
     /// Called once at the first occurrence of the hook. Implement this to
     /// initialize your data.
     fn initialize(&mut self, _ctx: &mut Context) {}
+
     /// Called every frame. Use the provided `ui` object to build your UI.
     fn render(&mut self, ui: &mut Ui, flags: &ImguiRenderLoopFlags);
+
+    /// Called during the window procedure.
+    fn on_wnd_proc(&self, _hwnd: HWND, _umsg: u32, _wparam: WPARAM, _lparam: LPARAM) {}
 
     /// If this function returns true, the WndProc function will not call the
     /// procedure of the parent window.

--- a/src/hooks/common/wnd_proc.rs
+++ b/src/hooks/common/wnd_proc.rs
@@ -296,6 +296,9 @@ where
     let wnd_proc = imgui_renderer.wnd_proc();
     let should_block_messages =
         imgui_render_loop.as_ref().should_block_messages(imgui_renderer.io());
+
+    imgui_render_loop.as_ref().on_wnd_proc(hwnd, umsg, WPARAM(wparam), LPARAM(lparam));
+
     drop(imgui_renderer);
 
     if should_block_messages {

--- a/src/hooks/dx11.rs
+++ b/src/hooks/dx11.rs
@@ -231,8 +231,6 @@ impl ImguiRenderer {
         let draw_data = ctx.render();
 
         if let Err(e) = self.engine.render_draw_data(draw_data) {
-            // if let Err(e) = self.engine.render(|ui| self.render_loop.render(ui,
-            // &self.flags)) {
             error!("ImGui renderer error: {:?}", e);
         }
     }


### PR DESCRIPTION
Closes #86.

The new API currently takes a shared reference to work around concurrency issues, until a proper concurrency overhaul is done.