### PR TITLE
Lock hooks and injection behind feature flags

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+target = "x86_64-pc-windows-gnu"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,0 @@
-[build]
-target = "x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,12 @@ default-target = "x86_64-pc-windows-msvc"
 targets = ["x86_64-pc-windows-msvc"]
 
 [features]
-default = ["dx9", "dx11", "dx12", "opengl3"]
+default = ["dx9", "dx11", "dx12", "opengl3", "inject"]
 dx9 = []
 dx11 = []
 dx12 = []
 opengl3 = []
+inject = []
 
 # Hook examples
 #

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -6,9 +6,13 @@
 //! [`imgui`]: https://docs.rs/imgui/0.8.0/imgui/
 
 pub(crate) mod common;
+#[cfg(feature = "dx11")]
 pub mod dx11;
+#[cfg(feature = "dx12")]
 pub mod dx12;
+#[cfg(feature = "dx9")]
 pub mod dx9;
+#[cfg(feature = "opengl3")]
 pub mod opengl3;
 
 pub use common::{ImguiRenderLoop, ImguiRenderLoopFlags};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,6 +116,7 @@
 mod mh;
 
 pub mod hooks;
+#[cfg(feature = "inject")]
 pub mod inject;
 pub mod renderers;
 


### PR DESCRIPTION
Locked all hooks and the injection part behind the feature flags, injection is behind `inject`.

Regarding #96 - It's fixed with this as I only enable OGL3, but there's another new issue that only occur with the Linux -> Windows build process, where it fails get some user profile directory (logged by CE).
Not a big deal, but if you got time to look into it, please do.