### PR TITLE
Expose `hooks::common`

### DIFF
--- a/examples/dx11_host.rs
+++ b/examples/dx11_host.rs
@@ -84,7 +84,7 @@ pub fn main(_argc: i32, _argv: *const *const u8) {
                 println!(
                     "{}",
                     String::from_utf8_lossy(std::slice::from_raw_parts(
-                        diqm.pDescription as *const u8,
+                        diqm.pDescription,
                         diqm.DescriptionByteLength
                     ))
                 );

--- a/examples/renderers/dx11.rs
+++ b/examples/renderers/dx11.rs
@@ -88,7 +88,7 @@ pub fn main(_argc: i32, _argv: *const *const u8) {
                 eprintln!(
                     "{}",
                     String::from_utf8_lossy(std::slice::from_raw_parts(
-                        diqm.pDescription as *const u8,
+                        diqm.pDescription,
                         diqm.DescriptionByteLength
                     ))
                 );

--- a/examples/renderers/dx12.rs
+++ b/examples/renderers/dx12.rs
@@ -178,7 +178,7 @@ pub fn main(_argc: i32, _argv: *const *const u8) {
                 println!(
                     "{}",
                     String::from_utf8_lossy(std::slice::from_raw_parts(
-                        diqm.pDescription as *const u8,
+                        diqm.pDescription,
                         diqm.DescriptionByteLength
                     ))
                 );

--- a/examples/renderers/dx9.rs
+++ b/examples/renderers/dx9.rs
@@ -156,7 +156,7 @@ pub fn main(_argc: i32, _argv: *const *const u8) {
                 eprintln!(
                     "{}",
                     String::from_utf8_lossy(std::slice::from_raw_parts(
-                        diqm.pDescription as *const u8,
+                        diqm.pDescription,
                         diqm.DescriptionByteLength
                     ))
                 );

--- a/src/hooks/common/wnd_proc.rs
+++ b/src/hooks/common/wnd_proc.rs
@@ -232,7 +232,7 @@ fn handle_input(io: &mut Io, state: u32, WPARAM(wparam): WPARAM, LPARAM(lparam):
 ////////////////////////////////////////////////////////////////////////////////
 
 #[must_use]
-pub(crate) fn imgui_wnd_proc_impl<T>(
+pub fn imgui_wnd_proc_impl<T>(
     hwnd: HWND,
     umsg: u32,
     WPARAM(wparam): WPARAM,

--- a/src/hooks/dx11.rs
+++ b/src/hooks/dx11.rs
@@ -31,11 +31,8 @@ use windows::Win32::UI::WindowsAndMessaging::SetWindowLongA;
 use windows::Win32::UI::WindowsAndMessaging::SetWindowLongPtrA;
 use windows::Win32::UI::WindowsAndMessaging::*;
 
-use crate::hooks::common::{
-    imgui_wnd_proc_impl, DummyHwnd, ImguiRenderLoop, ImguiRenderLoopFlags,
-    ImguiWindowsEventHandler, WndProcType,
-};
-use crate::hooks::Hooks;
+use crate::hooks::common::{imgui_wnd_proc_impl, DummyHwnd, ImguiWindowsEventHandler, WndProcType};
+use crate::hooks::{Hooks, ImguiRenderLoop, ImguiRenderLoopFlags};
 use crate::mh::{MhHook, MhHooks};
 use crate::renderers::imgui_dx11;
 

--- a/src/hooks/dx12.rs
+++ b/src/hooks/dx12.rs
@@ -154,7 +154,7 @@ unsafe fn print_dxgi_debug_messages() {
         debug!(
             "[DIQ] {}",
             String::from_utf8_lossy(std::slice::from_raw_parts(
-                diqm.pDescription as *const u8,
+                diqm.pDescription,
                 diqm.DescriptionByteLength - 1
             ))
         );

--- a/src/hooks/dx12.rs
+++ b/src/hooks/dx12.rs
@@ -33,11 +33,8 @@ use windows::Win32::UI::WindowsAndMessaging::SetWindowLongA;
 use windows::Win32::UI::WindowsAndMessaging::SetWindowLongPtrA;
 use windows::Win32::UI::WindowsAndMessaging::*;
 
-use crate::hooks::common::{
-    imgui_wnd_proc_impl, DummyHwnd, ImguiRenderLoop, ImguiRenderLoopFlags,
-    ImguiWindowsEventHandler, WndProcType,
-};
-use crate::hooks::Hooks;
+use crate::hooks::common::{imgui_wnd_proc_impl, DummyHwnd, ImguiWindowsEventHandler, WndProcType};
+use crate::hooks::{Hooks, ImguiRenderLoop, ImguiRenderLoopFlags};
 use crate::mh::{MhHook, MhHooks};
 use crate::renderers::imgui_dx12::RenderEngine;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,11 +113,10 @@
 //! ```
 #![allow(clippy::needless_doctest_main)]
 
-mod mh;
-
 pub mod hooks;
 #[cfg(feature = "inject")]
 pub mod inject;
+pub mod mh;
 pub mod renderers;
 
 /// Utility functions.

--- a/src/renderers/imgui_dx9.rs
+++ b/src/renderers/imgui_dx9.rs
@@ -317,8 +317,8 @@ impl Renderer {
     }
 
     unsafe fn lock_buffers<'v, 'i>(
-        vb: &'v mut IDirect3DVertexBuffer9,
-        ib: &'i mut IDirect3DIndexBuffer9,
+        vb: &'v IDirect3DVertexBuffer9,
+        ib: &'i IDirect3DIndexBuffer9,
         vtx_count: usize,
         idx_count: usize,
     ) -> Result<(&'v mut [CustomVertex], &'i mut [DrawIdx])> {
@@ -351,8 +351,8 @@ impl Renderer {
 
     unsafe fn write_buffers(&mut self, draw_data: &DrawData) -> Result<()> {
         let (mut vtx_dst, mut idx_dst) = Self::lock_buffers(
-            &mut self.vertex_buffer.0,
-            &mut self.index_buffer.0,
+            &self.vertex_buffer.0,
+            &self.index_buffer.0,
             draw_data.total_vtx_count as usize,
             draw_data.total_idx_count as usize,
         )?;

--- a/tests/harness/dx11.rs
+++ b/tests/harness/dx11.rs
@@ -132,7 +132,7 @@ impl Dx11Harness {
                             eprintln!(
                                 "{}",
                                 String::from_utf8_lossy(std::slice::from_raw_parts(
-                                    diqm.pDescription as *const u8,
+                                    diqm.pDescription,
                                     diqm.DescriptionByteLength
                                 ))
                             );

--- a/tests/harness/dx12.rs
+++ b/tests/harness/dx12.rs
@@ -194,7 +194,7 @@ impl Dx12Harness {
                             println!(
                                 "{}",
                                 String::from_utf8_lossy(std::slice::from_raw_parts(
-                                    diqm.pDescription as *const u8,
+                                    diqm.pDescription,
                                     diqm.DescriptionByteLength
                                 ))
                             );


### PR DESCRIPTION
This PR exposes the traits and types in `hooks::common`, and other utilities like the `mh` module, so that third parties can independently implement their own renderers and hooks.

Closes #85.