### PR TITLE
Remove focus flag and `ImguiRenderLoopFlags`

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Read up on the underlying architecture [here](https://veeenu.github.io/blog/seki
 ```rust
 // src/lib.rs
 use hudhook::hooks::dx11::ImguiDX11Hooks;
-use hudhook::hooks::{ImguiRenderLoop, ImguiRenderLoopFlags};
+use hudhook::hooks::ImguiRenderLoop;
 use imgui::{Condition, Window};
 struct Dx11HookExample;
 
@@ -35,7 +35,7 @@ impl Dx11HookExample {
 }
 
 impl ImguiRenderLoop for Dx11HookExample {
-    fn render(&mut self, ui: &mut imgui::Ui, _: &ImguiRenderLoopFlags) {
+    fn render(&mut self, ui: &mut imgui::Ui) {
         ui.window("Hello world").size([300.0, 110.0], Condition::FirstUseEver).build(|| {
             ui.text("Hello world!");
             ui.text("こんにちは世界！");

--- a/examples/dx11_hook.rs
+++ b/examples/dx11_hook.rs
@@ -1,7 +1,7 @@
 #![feature(lazy_cell)]
 
 use hudhook::hooks::dx11::ImguiDx11Hooks;
-use hudhook::hooks::{ImguiRenderLoop, ImguiRenderLoopFlags};
+use hudhook::hooks::ImguiRenderLoop;
 use imgui::Condition;
 use tracing::metadata::LevelFilter;
 struct Dx11HookExample;
@@ -25,7 +25,7 @@ impl Dx11HookExample {
 }
 
 impl ImguiRenderLoop for Dx11HookExample {
-    fn render(&mut self, ui: &mut imgui::Ui, _: &ImguiRenderLoopFlags) {
+    fn render(&mut self, ui: &mut imgui::Ui) {
         ui.window("Hello world").size([300.0, 110.0], Condition::FirstUseEver).build(|| {
             ui.text("Hello world!");
             ui.text("こんにちは世界！");

--- a/examples/dx12_hook.rs
+++ b/examples/dx12_hook.rs
@@ -1,7 +1,7 @@
 #![feature(lazy_cell)]
 
 use hudhook::hooks::dx12::ImguiDx12Hooks;
-use hudhook::hooks::{ImguiRenderLoop, ImguiRenderLoopFlags};
+use hudhook::hooks::ImguiRenderLoop;
 use imgui::Condition;
 use tracing::metadata::LevelFilter;
 struct Dx12HookExample;
@@ -25,7 +25,7 @@ impl Dx12HookExample {
 }
 
 impl ImguiRenderLoop for Dx12HookExample {
-    fn render(&mut self, ui: &mut imgui::Ui, _: &ImguiRenderLoopFlags) {
+    fn render(&mut self, ui: &mut imgui::Ui) {
         ui.window("Hello world").size([300.0, 110.0], Condition::FirstUseEver).build(|| {
             ui.text("Hello world!");
             ui.text("こんにちは世界！");

--- a/examples/dx9_hook.rs
+++ b/examples/dx9_hook.rs
@@ -1,7 +1,7 @@
 #![feature(lazy_cell)]
 
 use hudhook::hooks::dx9::ImguiDx9Hooks;
-use hudhook::hooks::{ImguiRenderLoop, ImguiRenderLoopFlags};
+use hudhook::hooks::ImguiRenderLoop;
 use imgui::Condition;
 use tracing::metadata::LevelFilter;
 struct Dx9HookExample;
@@ -25,7 +25,7 @@ impl Dx9HookExample {
 }
 
 impl ImguiRenderLoop for Dx9HookExample {
-    fn render(&mut self, ui: &mut imgui::Ui, _: &ImguiRenderLoopFlags) {
+    fn render(&mut self, ui: &mut imgui::Ui) {
         ui.window("Hello world").size([300.0, 110.0], Condition::FirstUseEver).build(|| {
             ui.text("Hello world!");
             ui.text("こんにちは世界！");

--- a/examples/opengl3_hook.rs
+++ b/examples/opengl3_hook.rs
@@ -1,7 +1,7 @@
 #![feature(lazy_cell)]
 
 use hudhook::hooks::opengl3::ImguiOpenGl3Hooks;
-use hudhook::hooks::{ImguiRenderLoop, ImguiRenderLoopFlags};
+use hudhook::hooks::ImguiRenderLoop;
 use imgui::Condition;
 use tracing::metadata::LevelFilter;
 struct HookYou;
@@ -25,7 +25,7 @@ impl HookYou {
 }
 
 impl ImguiRenderLoop for HookYou {
-    fn render(&mut self, ui: &mut imgui::Ui, _: &ImguiRenderLoopFlags) {
+    fn render(&mut self, ui: &mut imgui::Ui) {
         ui.window("Hello world").size([300.0, 110.0], Condition::FirstUseEver).build(|| {
             ui.text("Hello world!");
             ui.text("こんにちは世界！");

--- a/hudbook/hello-hud/src/lib.rs
+++ b/hudbook/hello-hud/src/lib.rs
@@ -1,8 +1,7 @@
 use std::time::Instant;
 
-
-use hudhook::hooks::{ImguiRenderLoop, ImguiRenderLoopFlags};
 use hudhook::hooks::dx12::ImguiDx12Hooks;
+use hudhook::hooks::ImguiRenderLoop;
 use imgui::*;
 
 struct HelloHud {
@@ -16,13 +15,11 @@ impl HelloHud {
 }
 
 impl ImguiRenderLoop for HelloHud {
-    fn render(&mut self, ui: &mut Ui, _flags: &ImguiRenderLoopFlags) {
-        ui.window("##hello")
-            .size([320., 200.], Condition::Always)
-            .build(|| {
-                ui.text("Hello, world!");
-                ui.text(format!("Elapsed: {:?}", self.start_time.elapsed()));
-            });
+    fn render(&mut self, ui: &mut Ui) {
+        ui.window("##hello").size([320., 200.], Condition::Always).build(|| {
+            ui.text("Hello, world!");
+            ui.text(format!("Elapsed: {:?}", self.start_time.elapsed()));
+        });
     }
 }
 

--- a/hudbook/src/creating-library/writing-dll.md
+++ b/hudbook/src/creating-library/writing-dll.md
@@ -27,12 +27,12 @@ The trait consists of only one method, `render`. `hudhook` will supply the `imgu
 need to use to render our UI, we are only tasked with actually implementing our rendering code.
 
 ```rust
-use hudhook::hooks::{ImguiRenderLoop, ImguiRenderLoopFlags};
+use hudhook::hooks::ImguiRenderLoop;
 use imgui::*;
 
 
 impl ImguiRenderLoop for HelloHud {
-    fn render(&mut self, ui: &mut Ui, _flags: &ImguiRenderLoopFlags) {
+    fn render(&mut self, ui: &mut Ui) {
         ui.window("##hello")
             .size([320., 200.], Condition::Always)
             .build(|| {

--- a/src/hooks/common/mod.rs
+++ b/src/hooks/common/mod.rs
@@ -60,9 +60,6 @@ pub trait ImguiWindowsEventHandler {
     fn io(&self) -> &imgui::Io;
     fn io_mut(&mut self) -> &mut imgui::Io;
 
-    fn focus(&self) -> bool;
-    fn focus_mut(&mut self) -> &mut bool;
-
     fn wnd_proc(&self) -> WndProcType;
 
     fn setup_io(&mut self) {

--- a/src/hooks/common/wnd_proc.rs
+++ b/src/hooks/common/wnd_proc.rs
@@ -17,7 +17,7 @@ use windows::Win32::UI::Input::{
 use windows::Win32::UI::WindowsAndMessaging::*;
 
 use super::{ImguiRenderLoop, ImguiWindowsEventHandler};
-use crate::hooks::{get_wheel_delta_wparam, hiword, loword};
+use crate::hooks::{get_wheel_delta_wparam, hiword};
 
 ////////////////////////////////////////////////////////////////////////////////
 // Raw input
@@ -286,10 +286,6 @@ where
             io.mouse_wheel_h += (wheel_delta_wparam as i16 as f32) / wheel_delta;
         },
         WM_CHAR => io.add_input_character(wparam as u8 as char),
-        WM_ACTIVATE => {
-            *imgui_renderer.focus_mut() = loword(wparam as _) != WA_INACTIVE as u16;
-            return LRESULT(1);
-        },
         _ => {},
     };
 

--- a/src/hooks/dx11.rs
+++ b/src/hooks/dx11.rs
@@ -266,14 +266,6 @@ impl ImguiWindowsEventHandler for ImguiRenderer {
         self.ctx_mut().io_mut()
     }
 
-    fn focus(&self) -> bool {
-        self.io().want_capture_mouse
-    }
-
-    fn focus_mut(&mut self) -> &mut bool {
-        &mut self.io_mut().want_capture_mouse
-    }
-
     fn wnd_proc(&self) -> WndProcType {
         self.wnd_proc
     }

--- a/src/hooks/dx12.rs
+++ b/src/hooks/dx12.rs
@@ -604,14 +604,6 @@ impl ImguiWindowsEventHandler for ImguiRenderer {
         self.ctx.io_mut()
     }
 
-    fn focus(&self) -> bool {
-        self.io().want_capture_mouse
-    }
-
-    fn focus_mut(&mut self) -> &mut bool {
-        &mut self.io_mut().want_capture_mouse
-    }
-
     fn wnd_proc(&self) -> WndProcType {
         self.wnd_proc
     }

--- a/src/hooks/dx9.rs
+++ b/src/hooks/dx9.rs
@@ -212,14 +212,6 @@ impl ImguiWindowsEventHandler for ImguiRenderer {
         self.ctx.io_mut()
     }
 
-    fn focus(&self) -> bool {
-        self.ctx.io().want_capture_mouse
-    }
-
-    fn focus_mut(&mut self) -> &mut bool {
-        &mut self.ctx.io_mut().want_capture_mouse
-    }
-
     fn wnd_proc(&self) -> WndProcType {
         self.wnd_proc
     }

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -20,13 +20,6 @@ pub mod dx9;
 #[cfg(feature = "opengl3")]
 pub mod opengl3;
 
-/// Holds information useful to the render loop which can't be retrieved from
-/// `imgui::Ui`.
-pub struct ImguiRenderLoopFlags {
-    /// Whether the hooked program's window is currently focused.
-    pub focused: bool,
-}
-
 /// Implement your `imgui` rendering logic via this trait.
 pub trait ImguiRenderLoop {
     /// Called once at the first occurrence of the hook. Implement this to
@@ -34,7 +27,7 @@ pub trait ImguiRenderLoop {
     fn initialize(&mut self, _ctx: &mut Context) {}
 
     /// Called every frame. Use the provided `ui` object to build your UI.
-    fn render(&mut self, ui: &mut Ui, flags: &ImguiRenderLoopFlags);
+    fn render(&mut self, ui: &mut Ui);
 
     /// Called during the window procedure.
     fn on_wnd_proc(&self, _hwnd: HWND, _umsg: u32, _wparam: WPARAM, _lparam: LPARAM) {}

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -47,10 +47,10 @@ pub trait ImguiRenderLoop {
     }
 }
 
-#[inline]
-fn loword(l: u32) -> u16 {
-    (l & 0xffff) as u16
-}
+// #[inline]
+// fn loword(l: u32) -> u16 {
+//     (l & 0xffff) as u16
+// }
 #[inline]
 fn hiword(l: u32) -> u16 {
     ((l >> 16) & 0xffff) as u16

--- a/src/hooks/opengl3.rs
+++ b/src/hooks/opengl3.rs
@@ -21,7 +21,7 @@ use windows::Win32::UI::WindowsAndMessaging::{
 };
 
 use crate::hooks::common::{imgui_wnd_proc_impl, ImguiWindowsEventHandler, WndProcType};
-use crate::hooks::{Hooks, ImguiRenderLoop, ImguiRenderLoopFlags};
+use crate::hooks::{Hooks, ImguiRenderLoop};
 use crate::mh::{MhHook, MhHooks};
 use crate::renderers::imgui_opengl3::get_proc_address;
 
@@ -65,7 +65,6 @@ unsafe fn draw(dc: HDC) {
                 ctx: context,
                 renderer,
                 wnd_proc,
-                flags: ImguiRenderLoopFlags { focused: false },
                 game_hwnd: hwnd,
                 resolution_and_rect: None,
             };
@@ -163,7 +162,6 @@ struct ImguiRenderer {
     ctx: Context,
     renderer: imgui_opengl::Renderer,
     wnd_proc: WndProcType,
-    flags: ImguiRenderLoopFlags,
     game_hwnd: HWND,
     resolution_and_rect: Option<([i32; 2], RECT)>,
 }
@@ -212,7 +210,7 @@ impl ImguiRenderer {
 
         let ui = self.ctx.frame();
 
-        IMGUI_RENDER_LOOP.get_mut().unwrap().render(ui, &self.flags);
+        IMGUI_RENDER_LOOP.get_mut().unwrap().render(ui);
         self.renderer.render(&mut self.ctx);
     }
 
@@ -235,11 +233,11 @@ impl ImguiWindowsEventHandler for ImguiRenderer {
     }
 
     fn focus(&self) -> bool {
-        self.flags.focused
+        self.ctx.io().want_capture_mouse
     }
 
     fn focus_mut(&mut self) -> &mut bool {
-        &mut self.flags.focused
+        &mut self.ctx.io_mut().want_capture_mouse
     }
 
     fn wnd_proc(&self) -> WndProcType {

--- a/src/hooks/opengl3.rs
+++ b/src/hooks/opengl3.rs
@@ -232,14 +232,6 @@ impl ImguiWindowsEventHandler for ImguiRenderer {
         self.ctx.io_mut()
     }
 
-    fn focus(&self) -> bool {
-        self.ctx.io().want_capture_mouse
-    }
-
-    fn focus_mut(&mut self) -> &mut bool {
-        &mut self.ctx.io_mut().want_capture_mouse
-    }
-
     fn wnd_proc(&self) -> WndProcType {
         self.wnd_proc
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,13 +51,13 @@
 //!
 //! ```no_run
 //! // lib.rs
-//! use hudhook::hooks::{ImguiRenderLoop, ImguiRenderLoopFlags};
+//! use hudhook::hooks::ImguiRenderLoop;
 //! use hudhook::*;
 //!
 //! pub struct MyRenderLoop;
 //!
 //! impl ImguiRenderLoop for MyRenderLoop {
-//!     fn render(&mut self, ui: &mut imgui::Ui, flags: &ImguiRenderLoopFlags) {
+//!     fn render(&mut self, ui: &mut imgui::Ui) {
 //!         ui.window("My first render loop")
 //!             .position([0., 0.], imgui::Condition::FirstUseEver)
 //!             .size([320., 200.], imgui::Condition::FirstUseEver)
@@ -259,13 +259,13 @@ pub mod reexports {
 /// Example usage:
 /// ```no_run
 /// use hudhook::hooks::dx12::ImguiDx12Hooks;
-/// use hudhook::hooks::{ImguiRenderLoop, ImguiRenderLoopFlags};
+/// use hudhook::hooks::ImguiRenderLoop;
 /// use hudhook::*;
 ///
 /// pub struct MyRenderLoop;
 ///
 /// impl ImguiRenderLoop for MyRenderLoop {
-///     fn render(&mut self, frame: &mut imgui::Ui, flags: &ImguiRenderLoopFlags) {
+///     fn render(&mut self, frame: &mut imgui::Ui) {
 ///         // ...
 ///     }
 /// }

--- a/tests/dx11.rs
+++ b/tests/dx11.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 
 use harness::dx11::Dx11Harness;
 use hudhook::hooks::dx11::ImguiDx11Hooks;
-use hudhook::hooks::{self, ImguiRenderLoop, ImguiRenderLoopFlags};
+use hudhook::hooks::{self, ImguiRenderLoop};
 use imgui::{Condition, StyleColor};
 use tracing::metadata::LevelFilter;
 
@@ -23,7 +23,7 @@ fn test_imgui_dx11() {
     }
 
     impl ImguiRenderLoop for Dx11HookExample {
-        fn render(&mut self, ui: &mut imgui::Ui, _: &ImguiRenderLoopFlags) {
+        fn render(&mut self, ui: &mut imgui::Ui) {
             ui.window("Hello world").size([300.0, 300.0], Condition::FirstUseEver).build(|| {
                 ui.text("Hello world!");
                 ui.text("こんにちは世界！");

--- a/tests/dx12.rs
+++ b/tests/dx12.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 
 use harness::dx12::Dx12Harness;
 use hudhook::hooks::dx12::ImguiDx12Hooks;
-use hudhook::hooks::{self, ImguiRenderLoop, ImguiRenderLoopFlags};
+use hudhook::hooks::{self, ImguiRenderLoop};
 use imgui::Condition;
 use tracing::metadata::LevelFilter;
 
@@ -23,7 +23,7 @@ fn test_imgui_dx12() {
     }
 
     impl ImguiRenderLoop for Dx12HookExample {
-        fn render(&mut self, ui: &mut imgui::Ui, _: &ImguiRenderLoopFlags) {
+        fn render(&mut self, ui: &mut imgui::Ui) {
             ui.window("Hello world").size([300.0, 300.0], Condition::FirstUseEver).build(|| {
                 ui.text("Hello world!");
                 ui.text("こんにちは世界！");

--- a/tests/opengl3.rs
+++ b/tests/opengl3.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 
 use harness::opengl3::Opengl3Harness;
 use hudhook::hooks::opengl3::ImguiOpenGl3Hooks;
-use hudhook::hooks::{self, ImguiRenderLoop, ImguiRenderLoopFlags};
+use hudhook::hooks::{self, ImguiRenderLoop};
 use imgui::Condition;
 use tracing::metadata::LevelFilter;
 use tracing::trace;
@@ -24,7 +24,7 @@ fn test_imgui_opengl3() {
     }
 
     impl ImguiRenderLoop for Opengl3HookExample {
-        fn render(&mut self, ui: &mut imgui::Ui, _: &ImguiRenderLoopFlags) {
+        fn render(&mut self, ui: &mut imgui::Ui) {
             ui.window("Hello world").size([300.0, 300.0], Condition::FirstUseEver).build(|| {
                 ui.text("Hello world!");
                 ui.text("こんにちは世界！");


### PR DESCRIPTION
This PR deprecates the `ImguiRenderLoopFlags`.
This is a breaking change, but it simplifies the outer API. 

There is no need for that "focused" flag as it was only ever updated by a `WM_ACTIVATE` event. No other events would arrive when the windows is inactive anyway, so there is no way of getting spurious inputs, which the flag was originally intended for anyway, back when the input loop would use `GetAsyncKeyState`.

Closes #120.