### PR TITLE
Bump `windows` to 0.51

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,9 +78,10 @@ crate-type = ["bin"]
 imgui = "0.11"
 imgui-opengl = "0.1"
 parking_lot = "0.12"
-windows = { version = "0.39.0", features = [
+windows = { version = "0.51.0", features = [
   "Win32_Devices_HumanInterfaceDevice",
   "Win32_Foundation",
+  "Foundation_Numerics",
   "Win32_Security",
   "Win32_System_Console",
   "Win32_System_Diagnostics_Debug",

--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@ overlays, largely inspired by [CheatEngine](https://cheatengine.org/).
 
 Currently supports DirectX 9, DirectX 11, DirectX 12 and OpenGL 3.
 
-Compiles on Rust nightly only.
-
 Read the tutorial book [here](https://veeenu.github.io/hudhook).
 
 Read the API reference [here](https://veeenu.github.io/hudhook/rustdoc/hudhook).

--- a/examples/dx11_hook.rs
+++ b/examples/dx11_hook.rs
@@ -1,5 +1,3 @@
-#![feature(lazy_cell)]
-
 use hudhook::hooks::dx11::ImguiDx11Hooks;
 use hudhook::hooks::ImguiRenderLoop;
 use imgui::Condition;
@@ -9,7 +7,7 @@ struct Dx11HookExample;
 impl Dx11HookExample {
     fn new() -> Self {
         println!("Initializing");
-        hudhook::alloc_console();
+        hudhook::alloc_console().expect("AllocConsole");
         hudhook::enable_console_colors();
 
         tracing_subscriber::fmt()

--- a/examples/dx12_hook.rs
+++ b/examples/dx12_hook.rs
@@ -1,5 +1,3 @@
-#![feature(lazy_cell)]
-
 use hudhook::hooks::dx12::ImguiDx12Hooks;
 use hudhook::hooks::ImguiRenderLoop;
 use imgui::Condition;
@@ -9,7 +7,7 @@ struct Dx12HookExample;
 impl Dx12HookExample {
     fn new() -> Self {
         println!("Initializing");
-        hudhook::alloc_console();
+        hudhook::alloc_console().expect("AllocConsole");
         hudhook::enable_console_colors();
 
         tracing_subscriber::fmt()

--- a/examples/dx9_hook.rs
+++ b/examples/dx9_hook.rs
@@ -1,5 +1,3 @@
-#![feature(lazy_cell)]
-
 use hudhook::hooks::dx9::ImguiDx9Hooks;
 use hudhook::hooks::ImguiRenderLoop;
 use imgui::Condition;
@@ -9,7 +7,7 @@ struct Dx9HookExample;
 impl Dx9HookExample {
     fn new() -> Self {
         println!("Initializing");
-        hudhook::alloc_console();
+        hudhook::alloc_console().expect("AllocConsole");
         hudhook::enable_console_colors();
 
         tracing_subscriber::fmt()

--- a/examples/opengl3_hook.rs
+++ b/examples/opengl3_hook.rs
@@ -1,5 +1,3 @@
-#![feature(lazy_cell)]
-
 use hudhook::hooks::opengl3::ImguiOpenGl3Hooks;
 use hudhook::hooks::ImguiRenderLoop;
 use imgui::Condition;
@@ -9,7 +7,7 @@ struct HookYou;
 impl HookYou {
     fn new() -> Self {
         println!("Initializing");
-        hudhook::alloc_console();
+        hudhook::alloc_console().expect("AllocConsole");
         hudhook::enable_console_colors();
 
         tracing_subscriber::fmt()

--- a/hudbook/src/creating-library/project-setup.md
+++ b/hudbook/src/creating-library/project-setup.md
@@ -19,14 +19,4 @@ crate-type = ["cdylib", "rlib"]
 name = "hello_hud"
 ```
 
-`hudhook` only supports Rust nightly, so let's create a `rust-toolchain.toml` at the top level of
-our crate, and paste the following content in it:
-
-```toml
-[toolchain]
-channel = "nightly"
-```
-
-This will instruct `cargo` to always use the nightly toolchain in the context of this project.
-
 We are now ready to start writing the code.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly"
+channel = "stable"

--- a/src/hooks/common/mod.rs
+++ b/src/hooks/common/mod.rs
@@ -3,8 +3,7 @@ use std::ptr::null;
 
 use imgui::Key;
 use tracing::debug;
-use windows::core::PCWSTR;
-use windows::w;
+use windows::core::{w, PCWSTR};
 use windows::Win32::Foundation::{HWND, LPARAM, LRESULT, WPARAM};
 use windows::Win32::Graphics::Gdi::HBRUSH;
 use windows::Win32::System::LibraryLoader::GetModuleHandleW;
@@ -120,12 +119,12 @@ impl DummyHwnd {
             lpfnWndProc: Some(wnd_proc),
             cbClsExtra: 0,
             cbWndExtra: 0,
-            hInstance: unsafe { GetModuleHandleW(None).unwrap() },
+            hInstance: unsafe { GetModuleHandleW(None).unwrap().into() },
             hIcon: HICON(0),
             hCursor: HCURSOR(0),
             hbrBackground: HBRUSH(0),
             lpszMenuName: PCWSTR(null()),
-            lpszClassName: w!("HUDHOOK").into(),
+            lpszClassName: w!("HUDHOOK"),
             hIconSm: HICON(0),
         };
         debug!("{:?}", wndclass);
@@ -145,7 +144,7 @@ impl DummyHwnd {
                 HWND_MESSAGE,
                 None,
                 wndclass.hInstance,
-                null(),
+                None,
             )
         };
         debug!("{:?}", hwnd);
@@ -163,8 +162,8 @@ impl Drop for DummyHwnd {
     fn drop(&mut self) {
         // Destroy the window and unregister the class.
         unsafe {
-            DestroyWindow(self.0);
-            UnregisterClassW(self.1.lpszClassName, self.1.hInstance);
+            DestroyWindow(self.0).expect("DestroyWindow");
+            UnregisterClassW(self.1.lpszClassName, self.1.hInstance).expect("DestroyWindow");
         }
     }
 }

--- a/src/hooks/common/wnd_proc.rs
+++ b/src/hooks/common/wnd_proc.rs
@@ -6,9 +6,9 @@ use imgui::Io;
 use parking_lot::MutexGuard;
 use windows::Win32::Foundation::{HWND, LPARAM, LRESULT, WPARAM};
 use windows::Win32::UI::Input::KeyboardAndMouse::{
-    MapVirtualKeyA, VIRTUAL_KEY, VK_CONTROL, VK_LBUTTON, VK_LCONTROL, VK_LMENU, VK_LSHIFT, VK_LWIN,
-    VK_MBUTTON, VK_MENU, VK_RBUTTON, VK_RCONTROL, VK_RMENU, VK_RSHIFT, VK_RWIN, VK_SHIFT,
-    VK_XBUTTON1, VK_XBUTTON2,
+    MapVirtualKeyA, MAPVK_VSC_TO_VK_EX, VIRTUAL_KEY, VK_CONTROL, VK_LBUTTON, VK_LCONTROL, VK_LMENU,
+    VK_LSHIFT, VK_LWIN, VK_MBUTTON, VK_MENU, VK_RBUTTON, VK_RCONTROL, VK_RMENU, VK_RSHIFT, VK_RWIN,
+    VK_SHIFT, VK_XBUTTON1, VK_XBUTTON2,
 };
 use windows::Win32::UI::Input::{
     GetRawInputData, HRAWINPUT, RAWINPUT, RAWINPUTHEADER, RAWKEYBOARD, RAWMOUSE_0_0,
@@ -150,7 +150,7 @@ fn handle_raw_input(io: &mut Io, WPARAM(wparam): WPARAM, LPARAM(lparam): LPARAM)
         GetRawInputData(
             HRAWINPUT(lparam),
             RID_INPUT,
-            &mut raw_data as *mut _ as _,
+            Some(&mut raw_data as *mut _ as _),
             &mut raw_data_size,
             raw_data_header_size,
         )
@@ -259,7 +259,7 @@ where
             io.mouse_down[2] = true;
         },
         WM_XBUTTONDOWN | WM_XBUTTONDBLCLK => {
-            let btn = if hiword(wparam as _) == XBUTTON1.0 as u16 { 3 } else { 4 };
+            let btn = if hiword(wparam as _) == XBUTTON1 { 3 } else { 4 };
             io.mouse_down[btn] = true;
         },
         WM_LBUTTONUP => {
@@ -272,7 +272,7 @@ where
             io.mouse_down[2] = false;
         },
         WM_XBUTTONUP => {
-            let btn = if hiword(wparam as _) == XBUTTON1.0 as u16 { 3 } else { 4 };
+            let btn = if hiword(wparam as _) == XBUTTON1 { 3 } else { 4 };
             io.mouse_down[btn] = false;
         },
         WM_MOUSEWHEEL => {

--- a/src/hooks/common/wnd_proc.rs
+++ b/src/hooks/common/wnd_proc.rs
@@ -1,5 +1,6 @@
 //! This module contains functions related to processing input events.
 
+use std::ffi::c_void;
 use std::mem::size_of;
 
 use imgui::Io;
@@ -150,7 +151,7 @@ fn handle_raw_input(io: &mut Io, WPARAM(wparam): WPARAM, LPARAM(lparam): LPARAM)
         GetRawInputData(
             HRAWINPUT(lparam),
             RID_INPUT,
-            Some(&mut raw_data as *mut _ as _),
+            Some(&mut raw_data as *mut _ as *mut c_void),
             &mut raw_data_size,
             raw_data_header_size,
         )

--- a/src/hooks/dx11.rs
+++ b/src/hooks/dx11.rs
@@ -1,6 +1,5 @@
 use std::ffi::c_void;
 use std::mem;
-use std::ptr::null_mut;
 use std::sync::OnceLock;
 
 use imgui::Context;
@@ -161,10 +160,9 @@ impl ImguiRenderer {
         trace!("Initializing renderer");
 
         let dev: ID3D11Device = swap_chain.GetDevice().expect("GetDevice");
-        let mut dev_ctx: Option<ID3D11DeviceContext> = None;
-        dev.GetImmediateContext(&mut dev_ctx);
-        let dev_ctx = dev_ctx.unwrap();
-        let sd = swap_chain.GetDesc().expect("GetDesc");
+        let dev_ctx: ID3D11DeviceContext = dev.GetImmediateContext().expect("GetImmediateContext");
+        let mut sd: DXGI_SWAP_CHAIN_DESC = Default::default();
+        swap_chain.GetDesc(&mut sd).expect("GetDesc");
 
         let engine =
             imgui_dx11::RenderEngine::new_with_ptrs(dev, dev_ctx, swap_chain.clone(), &mut ctx);
@@ -195,7 +193,8 @@ impl ImguiRenderer {
         trace!("Present impl: Rendering");
 
         let swap_chain = self.store_swap_chain(swap_chain);
-        let sd = swap_chain.GetDesc().expect("GetDesc");
+        let mut sd: DXGI_SWAP_CHAIN_DESC = Default::default();
+        swap_chain.GetDesc(&mut sd).expect("GetDesc");
 
         if let Some(rect) = self.engine.get_client_rect() {
             let io = self.ctx_mut().io_mut();
@@ -210,13 +209,13 @@ impl ImguiRenderer {
                     || IsChild(active_window, sd.OutputWindow).as_bool())
             {
                 let gcp = GetCursorPos(&mut pos as *mut _);
-                if gcp.as_bool() && ScreenToClient(sd.OutputWindow, &mut pos as *mut _).as_bool() {
+                if gcp.is_ok() && ScreenToClient(sd.OutputWindow, &mut pos as *mut _).as_bool() {
                     io.mouse_pos[0] = pos.x as _;
                     io.mouse_pos[1] = pos.y as _;
                 }
             }
         } else {
-            trace!("GetWindowRect error: {:x}", GetLastError().0);
+            trace!("GetWindowRect error: {:?}", GetLastError());
         }
 
         let ctx = &mut self.ctx;
@@ -239,13 +238,14 @@ impl ImguiRenderer {
 
     unsafe fn cleanup(&mut self, swap_chain: Option<IDXGISwapChain>) {
         let swap_chain = self.store_swap_chain(swap_chain);
-        let desc = swap_chain.GetDesc().unwrap();
+        let mut sd = Default::default();
+        swap_chain.GetDesc(&mut sd).unwrap();
 
         #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-        SetWindowLongPtrA(desc.OutputWindow, GWLP_WNDPROC, self.wnd_proc as usize as isize);
+        SetWindowLongPtrA(sd.OutputWindow, GWLP_WNDPROC, self.wnd_proc as usize as isize);
 
         #[cfg(target_arch = "x86")]
-        SetWindowLongA(desc.OutputWindow, GWLP_WNDPROC, self.wnd_proc as usize as i32);
+        SetWindowLongA(sd.OutputWindow, GWLP_WNDPROC, self.wnd_proc as usize as i32);
     }
 
     fn ctx(&self) -> &imgui::Context {
@@ -294,9 +294,9 @@ fn get_present_addr() -> (DXGISwapChainPresentType, DXGISwapChainResizeBuffersTy
             D3D_DRIVER_TYPE_NULL,
             None,
             D3D11_CREATE_DEVICE_FLAG(0),
-            &[D3D_FEATURE_LEVEL_10_0, D3D_FEATURE_LEVEL_11_0],
+            Some(&[D3D_FEATURE_LEVEL_10_0, D3D_FEATURE_LEVEL_11_0]),
             D3D11_SDK_VERSION,
-            &DXGI_SWAP_CHAIN_DESC {
+            Some(&DXGI_SWAP_CHAIN_DESC {
                 BufferDesc: DXGI_MODE_DESC {
                     Format: DXGI_FORMAT_R8G8B8A8_UNORM,
                     ScanlineOrdering: DXGI_MODE_SCANLINE_ORDER_UNSPECIFIED,
@@ -310,11 +310,11 @@ fn get_present_addr() -> (DXGISwapChainPresentType, DXGISwapChainResizeBuffersTy
                 SwapEffect: DXGI_SWAP_EFFECT_DISCARD,
                 SampleDesc: DXGI_SAMPLE_DESC { Count: 1, ..Default::default() },
                 ..Default::default()
-            },
-            &mut p_swap_chain,
-            &mut p_device,
-            null_mut(),
-            &mut p_context,
+            }),
+            Some(&mut p_swap_chain),
+            Some(&mut p_device),
+            None,
+            Some(&mut p_context),
         )
         .expect("D3D11CreateDeviceAndSwapChain failed");
     }

--- a/src/hooks/dx12.rs
+++ b/src/hooks/dx12.rs
@@ -582,7 +582,7 @@ impl ImguiRenderer {
 
         let barrier = barriers.into_iter().next().unwrap();
 
-        let transition = ManuallyDrop::into_inner(barrier.Anonymous.Transition);
+        let transition = ManuallyDrop::into_inner(unsafe { barrier.Anonymous.Transition });
         let _ = ManuallyDrop::into_inner(transition.pResource);
 
         trace!("Rendering done in {:?}", render_start.elapsed());

--- a/src/hooks/dx12.rs
+++ b/src/hooks/dx12.rs
@@ -582,10 +582,8 @@ impl ImguiRenderer {
 
         let barrier = barriers.into_iter().next().unwrap();
 
-        unsafe {
-            let transition = ManuallyDrop::into_inner(barrier.Anonymous.Transition);
-            let _ = ManuallyDrop::into_inner(transition.pResource);
-        };
+        let transition = ManuallyDrop::into_inner(barrier.Anonymous.Transition);
+        let _ = ManuallyDrop::into_inner(transition.pResource);
 
         trace!("Rendering done in {:?}", render_start.elapsed());
         None

--- a/src/hooks/dx9.rs
+++ b/src/hooks/dx9.rs
@@ -176,7 +176,7 @@ impl ImguiRenderer {
                     || IsChild(active_window, self.renderer.get_hwnd()).as_bool())
             {
                 let gcp = GetCursorPos(&mut pos as *mut _);
-                if gcp.as_bool()
+                if gcp.is_ok()
                     && ScreenToClient(self.renderer.get_hwnd(), &mut pos as *mut _).as_bool()
                 {
                     io.mouse_pos[0] = pos.x as _;
@@ -184,7 +184,7 @@ impl ImguiRenderer {
                 }
             }
         } else {
-            trace!("GetWindowRect error: {:x}", GetLastError().0);
+            trace!("GetWindowRect error: {:?}", GetLastError());
         }
 
         let ui = self.ctx.frame();

--- a/src/hooks/opengl3.rs
+++ b/src/hooks/opengl3.rs
@@ -7,7 +7,7 @@ use parking_lot::Mutex;
 use tracing::{debug, trace};
 use windows::core::PCSTR;
 use windows::Win32::Foundation::{
-    GetLastError, BOOL, HANDLE, HWND, LPARAM, LRESULT, POINT, RECT, WPARAM,
+    GetLastError, HANDLE, HWND, LPARAM, LRESULT, POINT, RECT, WPARAM,
 };
 use windows::Win32::Graphics::Gdi::{ScreenToClient, WindowFromDC, HDC};
 use windows::Win32::Graphics::OpenGL::{glClearColor, glGetIntegerv, GL_VIEWPORT};
@@ -169,7 +169,7 @@ struct ImguiRenderer {
 fn get_client_rect(hwnd: &HWND) -> Option<RECT> {
     unsafe {
         let mut rect: RECT = core::mem::zeroed();
-        if GetClientRect(*hwnd, &mut rect) != BOOL(0) {
+        if GetClientRect(*hwnd, &mut rect).is_ok() {
             Some(rect)
         } else {
             None
@@ -192,13 +192,13 @@ impl ImguiRenderer {
                     || IsChild(active_window, self.game_hwnd).as_bool())
             {
                 let gcp = GetCursorPos(&mut pos as *mut _);
-                if gcp.as_bool() && ScreenToClient(self.game_hwnd, &mut pos as *mut _).as_bool() {
+                if gcp.is_ok() && ScreenToClient(self.game_hwnd, &mut pos as *mut _).as_bool() {
                     io.mouse_pos[0] = pos.x as _;
                     io.mouse_pos[1] = pos.y as _;
                 }
             }
         } else {
-            trace!("GetClientRect error: {:x}", GetLastError().0);
+            trace!("GetClientRect error: {:?}", GetLastError());
         }
 
         // Update the delta time of ImGui as to tell it how long has elapsed since the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,6 +137,8 @@ pub mod renderers;
 #[cfg(feature = "inject")]
 pub mod inject;
 
+mod util;
+
 // Global state objects.
 static mut MODULE: OnceCell<HINSTANCE> = OnceCell::new();
 static mut HUDHOOK: OnceCell<Hudhook> = OnceCell::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,12 +2,10 @@
 //!
 //! This library implements a mechanism for hooking into the
 //! render loop of applications and drawing things on screen via
-//! [`imgui`](https://docs.rs/imgui/0.8.0/imgui/). It has been largely inspired
+//! [`imgui`](https://docs.rs/imgui/0.11.0/imgui/). It has been largely inspired
 //! by [CheatEngine](https://www.cheatengine.org/).
 //!
 //! Currently, DirectX9, DirectX 11, DirectX 12 and OpenGL 3 are supported.
-//!
-//! This library **requires** Rust nightly.
 //!
 //! For complete, fully fledged examples of usage, check out the following
 //! projects:
@@ -118,6 +116,7 @@ use std::thread;
 
 use once_cell::sync::OnceCell;
 use tracing::error;
+use windows::core::Error;
 pub use windows::Win32::Foundation::HINSTANCE;
 use windows::Win32::System::Console::{
     AllocConsole, FreeConsole, GetConsoleMode, GetStdHandle, SetConsoleMode, CONSOLE_MODE,
@@ -144,10 +143,12 @@ static mut HUDHOOK: OnceCell<Hudhook> = OnceCell::new();
 static CONSOLE_ALLOCATED: AtomicBool = AtomicBool::new(false);
 
 /// Allocate a Windows console.
-pub fn alloc_console() {
+pub fn alloc_console() -> Result<(), Error> {
     if !CONSOLE_ALLOCATED.swap(true, Ordering::SeqCst) {
-        unsafe { AllocConsole() };
+        unsafe { AllocConsole()? };
     }
+
+    Ok(())
 }
 
 /// Enable console colors if the console is allocated.
@@ -172,10 +173,12 @@ pub fn enable_console_colors() {
 }
 
 /// Free the previously allocated Windows console.
-pub fn free_console() {
+pub fn free_console() -> Result<(), Error> {
     if CONSOLE_ALLOCATED.swap(false, Ordering::SeqCst) {
-        unsafe { FreeConsole() };
+        unsafe { FreeConsole()? };
     }
+
+    Ok(())
 }
 
 /// Disable hooks and eject the DLL.
@@ -190,7 +193,9 @@ pub fn free_console() {
 /// dropping/resetting the contents of static mutable variables).
 pub fn eject() {
     thread::spawn(|| unsafe {
-        free_console();
+        if let Err(e) = free_console() {
+            error!("{e:?}");
+        }
 
         if let Some(mut hudhook) = HUDHOOK.take() {
             if let Err(e) = hudhook.unapply() {
@@ -290,7 +295,6 @@ impl Hudhook {
 ///     _: *mut std::ffi::c_void,
 /// ) {
 ///     if reason == DLL_PROCESS_ATTACH {
-///         trace!("DllMain()");
 ///         std::thread::spawn(move || {
 ///             let hooks = Hudhook::builder()
 ///                 .with(MyRenderLoop.into_hook::<ImguiDx12Hooks>())
@@ -353,13 +357,13 @@ macro_rules! hudhook {
         /// Entry point created by the `hudhook` library.
         #[no_mangle]
         pub unsafe extern "stdcall" fn DllMain(
-            hmodule: HINSTANCE,
+            hmodule: ::hudhook::HINSTANCE,
             reason: u32,
-            _: *mut std::ffi::c_void,
+            _: *mut ::std::ffi::c_void,
         ) {
             if reason == DLL_PROCESS_ATTACH {
                 trace!("DllMain()");
-                std::thread::spawn(move || {
+                ::std::thread::spawn(move || {
                     if let Err(e) =
                         Hudhook::builder().with({ $hooks }).with_hmodule(hmodule).build().apply()
                     {

--- a/src/renderers/imgui_dx11.rs
+++ b/src/renderers/imgui_dx11.rs
@@ -1,9 +1,7 @@
-use std::ptr::null_mut;
-
 use imgui::internal::RawWrapper;
 use imgui::{Context, DrawCmd, DrawData, DrawListIterator, DrawVert};
 use tracing::{error, trace};
-use windows::core::{Error, PCSTR};
+use windows::core::{s, Error};
 use windows::Win32::Foundation::{BOOL, HWND, RECT};
 use windows::Win32::Graphics::Direct3D::Fxc::D3DCompile;
 use windows::Win32::Graphics::Direct3D::{
@@ -18,16 +16,15 @@ use windows::Win32::Graphics::Direct3D11::{
     D3D11_BIND_CONSTANT_BUFFER, D3D11_BIND_INDEX_BUFFER, D3D11_BIND_SHADER_RESOURCE,
     D3D11_BIND_VERTEX_BUFFER, D3D11_BLEND_DESC, D3D11_BLEND_INV_SRC_ALPHA, D3D11_BLEND_OP_ADD,
     D3D11_BLEND_SRC_ALPHA, D3D11_BLEND_ZERO, D3D11_BUFFER_DESC, D3D11_COLOR_WRITE_ENABLE_ALL,
-    D3D11_COMPARISON_ALWAYS, D3D11_CPU_ACCESS_FLAG, D3D11_CPU_ACCESS_WRITE,
-    D3D11_CREATE_DEVICE_DEBUG, D3D11_CREATE_DEVICE_FLAG, D3D11_CULL_NONE,
-    D3D11_DEPTH_STENCILOP_DESC, D3D11_DEPTH_STENCIL_DESC, D3D11_DEPTH_WRITE_MASK_ALL,
-    D3D11_FILL_SOLID, D3D11_FILTER_MIN_MAG_MIP_LINEAR, D3D11_INPUT_ELEMENT_DESC,
-    D3D11_INPUT_PER_VERTEX_DATA, D3D11_MAPPED_SUBRESOURCE, D3D11_MAP_WRITE_DISCARD,
-    D3D11_RASTERIZER_DESC, D3D11_RENDER_TARGET_BLEND_DESC, D3D11_RESOURCE_MISC_FLAG,
-    D3D11_SAMPLER_DESC, D3D11_SDK_VERSION, D3D11_SHADER_RESOURCE_VIEW_DESC,
-    D3D11_SHADER_RESOURCE_VIEW_DESC_0, D3D11_STENCIL_OP_KEEP, D3D11_SUBRESOURCE_DATA,
-    D3D11_TEX2D_SRV, D3D11_TEXTURE2D_DESC, D3D11_TEXTURE_ADDRESS_WRAP, D3D11_USAGE_DEFAULT,
-    D3D11_USAGE_DYNAMIC, D3D11_VIEWPORT,
+    D3D11_COMPARISON_ALWAYS, D3D11_CPU_ACCESS_WRITE, D3D11_CREATE_DEVICE_DEBUG,
+    D3D11_CREATE_DEVICE_FLAG, D3D11_CULL_NONE, D3D11_DEPTH_STENCILOP_DESC,
+    D3D11_DEPTH_STENCIL_DESC, D3D11_DEPTH_WRITE_MASK_ALL, D3D11_FILL_SOLID,
+    D3D11_FILTER_MIN_MAG_MIP_LINEAR, D3D11_INPUT_ELEMENT_DESC, D3D11_INPUT_PER_VERTEX_DATA,
+    D3D11_MAPPED_SUBRESOURCE, D3D11_MAP_WRITE_DISCARD, D3D11_RASTERIZER_DESC,
+    D3D11_RENDER_TARGET_BLEND_DESC, D3D11_SAMPLER_DESC, D3D11_SDK_VERSION,
+    D3D11_SHADER_RESOURCE_VIEW_DESC, D3D11_SHADER_RESOURCE_VIEW_DESC_0, D3D11_STENCIL_OP_KEEP,
+    D3D11_SUBRESOURCE_DATA, D3D11_TEX2D_SRV, D3D11_TEXTURE2D_DESC, D3D11_TEXTURE_ADDRESS_WRAP,
+    D3D11_USAGE_DEFAULT, D3D11_USAGE_DYNAMIC, D3D11_VIEWPORT,
 };
 use windows::Win32::Graphics::Dxgi::Common::{
     DXGI_FORMAT, DXGI_FORMAT_R16_UINT, DXGI_FORMAT_R32G32_FLOAT, DXGI_FORMAT_R32_UINT,
@@ -121,9 +118,9 @@ impl RenderEngine {
             dev_ctx.IASetVertexBuffers(
                 0,
                 1,
-                &Some(self.buffers.vtx_buffer()),
-                &(std::mem::size_of::<DrawVert>() as u32),
-                &0,
+                Some(&Some(self.buffers.vtx_buffer())),
+                Some(&(std::mem::size_of::<DrawVert>() as u32)),
+                Some(&0),
             );
             dev_ctx.IASetIndexBuffer(
                 &self.buffers.idx_buffer(),
@@ -135,8 +132,8 @@ impl RenderEngine {
                 0,
             );
             dev_ctx.IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
-            dev_ctx.VSSetConstantBuffers(0, &[Some(self.buffers.mtx_buffer())]);
-            dev_ctx.PSSetShaderResources(0, &[Some(self.texture.tex_view())]);
+            dev_ctx.VSSetConstantBuffers(0, Some(&[Some(self.buffers.mtx_buffer())]));
+            dev_ctx.PSSetShaderResources(0, Some(&[Some(self.texture.tex_view())]));
 
             let mut vtx_offset = 0usize;
             let mut idx_offset = 0usize;
@@ -148,12 +145,12 @@ impl RenderEngine {
                         DrawCmd::Elements { count, cmd_params } => {
                             trace!("Rendering {count} elements");
                             let [cx, cy, cw, ch] = cmd_params.clip_rect;
-                            dev_ctx.RSSetScissorRects(&[RECT {
+                            dev_ctx.RSSetScissorRects(Some(&[RECT {
                                 left: (cx - x) as i32,
                                 top: (cy - y) as i32,
                                 right: (cw - x) as i32,
                                 bottom: (ch - y) as i32,
-                            }]);
+                            }]));
 
                             // let srv = cmd_params.texture_id.id();
                             // We only load the font texture. This may not be correct.
@@ -216,9 +213,9 @@ impl DeviceAndSwapChain {
                 D3D_DRIVER_TYPE_HARDWARE,
                 None,
                 DEVICE_FLAGS,
-                &[],
+                Some(&[]),
                 D3D11_SDK_VERSION,
-                &DXGI_SWAP_CHAIN_DESC {
+                Some(&DXGI_SWAP_CHAIN_DESC {
                     BufferCount: 1,
                     BufferDesc: DXGI_MODE_DESC {
                         Format: DXGI_FORMAT_R8G8B8A8_UNORM,
@@ -234,11 +231,11 @@ impl DeviceAndSwapChain {
                     Windowed: BOOL(1),
                     SwapEffect: DXGI_SWAP_EFFECT(0),
                     Flags: 0,
-                } as *const _,
-                &mut swap_chain as *mut _,
-                &mut dev as *mut _,
-                null_mut(),
-                &mut dev_ctx as *mut _,
+                }),
+                Some(&mut swap_chain),
+                Some(&mut dev),
+                None,
+                Some(&mut dev_ctx),
             )
             .unwrap()
         };
@@ -258,24 +255,24 @@ impl DeviceAndSwapChain {
         let back_buffer = unsafe {
             let p_back_buffer: ID3D11Resource = swap_chain.GetBuffer(0).expect("GetBuffer");
 
-            let back_buffer = dev
-                .CreateRenderTargetView(&p_back_buffer, null_mut())
+            let mut back_buffer = None;
+            dev.CreateRenderTargetView(&p_back_buffer, None, Some(&mut back_buffer))
                 .expect("CreateRenderTargetView");
 
-            dev_ctx.OMSetRenderTargets(&[Some(back_buffer.clone())], None);
+            dev_ctx.OMSetRenderTargets(Some(&[back_buffer.clone()]), None);
 
-            back_buffer
+            back_buffer.unwrap()
         };
 
         unsafe {
-            dev_ctx.RSSetViewports(&[D3D11_VIEWPORT {
+            dev_ctx.RSSetViewports(Some(&[D3D11_VIEWPORT {
                 TopLeftX: 0.,
                 TopLeftY: 0.,
                 Width: 640.,
                 Height: 480.,
                 MinDepth: 0.,
                 MaxDepth: 1.,
-            }])
+            }]))
         };
 
         DeviceAndSwapChain { dev, dev_ctx, swap_chain, back_buffer }
@@ -289,33 +286,34 @@ impl DeviceAndSwapChain {
     }
 
     fn set_shader_resources(&self, srv: ID3D11ShaderResourceView) {
-        unsafe { self.dev_ctx.PSSetShaderResources(0, &[Some(srv)]) }
+        unsafe { self.dev_ctx.PSSetShaderResources(0, Some(&[Some(srv)])) }
     }
 
     fn set_viewport(&self, rect: RECT) {
         unsafe {
-            self.dev_ctx().RSSetViewports(&[D3D11_VIEWPORT {
+            self.dev_ctx().RSSetViewports(Some(&[D3D11_VIEWPORT {
                 TopLeftX: 0.,
                 TopLeftY: 0.,
                 Width: (rect.right - rect.left) as f32,
                 Height: (rect.bottom - rect.top) as f32,
                 MinDepth: 0.,
                 MaxDepth: 1.,
-            }])
+            }]))
         };
     }
 
     fn set_render_target(&self) {
         unsafe {
-            self.dev_ctx.OMSetRenderTargets(&[Some(self.back_buffer.clone())], None);
+            self.dev_ctx.OMSetRenderTargets(Some(&[Some(self.back_buffer.clone())]), None);
         }
     }
 
     fn get_client_rect(&self) -> Option<RECT> {
         unsafe {
-            let sd = self.swap_chain.GetDesc().expect("GetDesc");
+            let mut sd = Default::default();
+            self.swap_chain.GetDesc(&mut sd).expect("GetDesc");
             let mut rect: RECT = Default::default();
-            if GetClientRect(sd.OutputWindow, &mut rect as _) != BOOL(0) {
+            if GetClientRect(sd.OutputWindow, &mut rect as _).is_ok() {
                 Some(rect)
             } else {
                 None
@@ -328,7 +326,8 @@ impl DeviceAndSwapChain {
         F: FnOnce(&D3D11_MAPPED_SUBRESOURCE),
     {
         unsafe {
-            let ms = self.dev_ctx.Map(ptr, 0, D3D11_MAP_WRITE_DISCARD, 0).expect("Map");
+            let mut ms = Default::default();
+            self.dev_ctx.Map(ptr, 0, D3D11_MAP_WRITE_DISCARD, 0, Some(&mut ms)).expect("Map");
 
             f(&ms);
 
@@ -363,21 +362,24 @@ struct VertexConstantBuffer([[f32; 4]; 4]);
 
 impl Buffers {
     fn new(dasc: &DeviceAndSwapChain) -> Self {
-        let mtx_buffer = unsafe {
+        let mut mtx_buffer: Option<ID3D11Buffer> = None;
+        unsafe {
             dasc.dev()
                 .CreateBuffer(
                     &D3D11_BUFFER_DESC {
                         ByteWidth: std::mem::size_of::<VertexConstantBuffer>() as u32,
                         Usage: D3D11_USAGE_DYNAMIC,
-                        BindFlags: D3D11_BIND_CONSTANT_BUFFER.0,
-                        CPUAccessFlags: D3D11_CPU_ACCESS_WRITE.0,
+                        BindFlags: D3D11_BIND_CONSTANT_BUFFER.0 as u32,
+                        CPUAccessFlags: D3D11_CPU_ACCESS_WRITE.0 as u32,
                         MiscFlags: 0,
                         StructureByteStride: 0,
-                    } as *const _,
-                    null_mut(),
+                    },
+                    None,
+                    Some(&mut mtx_buffer),
                 )
                 .expect("CreateBuffer")
         };
+        let mtx_buffer = mtx_buffer.unwrap();
 
         let vtx_buffer = Buffers::create_vertex_buffer(dasc, 1);
         let idx_buffer = Buffers::create_index_buffer(dasc, 1);
@@ -437,39 +439,45 @@ impl Buffers {
     }
 
     fn create_vertex_buffer(dasc: &DeviceAndSwapChain, size: usize) -> ID3D11Buffer {
+        let mut buf: Option<ID3D11Buffer> = None;
         unsafe {
             dasc.dev()
                 .CreateBuffer(
                     &D3D11_BUFFER_DESC {
                         Usage: D3D11_USAGE_DYNAMIC,
                         ByteWidth: (size * std::mem::size_of::<imgui::DrawVert>()) as u32,
-                        BindFlags: D3D11_BIND_VERTEX_BUFFER.0,
-                        CPUAccessFlags: D3D11_CPU_ACCESS_WRITE.0,
+                        BindFlags: D3D11_BIND_VERTEX_BUFFER.0 as u32,
+                        CPUAccessFlags: D3D11_CPU_ACCESS_WRITE.0 as u32,
                         MiscFlags: 0,
                         StructureByteStride: 0,
                     },
-                    null_mut(),
+                    None,
+                    Some(&mut buf),
                 )
                 .expect("CreateBuffer")
-        }
+        };
+        buf.unwrap()
     }
 
     fn create_index_buffer(dasc: &DeviceAndSwapChain, size: usize) -> ID3D11Buffer {
+        let mut buf: Option<ID3D11Buffer> = None;
         unsafe {
             dasc.dev()
                 .CreateBuffer(
                     &D3D11_BUFFER_DESC {
                         Usage: D3D11_USAGE_DYNAMIC,
                         ByteWidth: (size * std::mem::size_of::<u32>()) as u32,
-                        BindFlags: D3D11_BIND_INDEX_BUFFER.0,
-                        CPUAccessFlags: D3D11_CPU_ACCESS_WRITE.0,
+                        BindFlags: D3D11_BIND_INDEX_BUFFER.0 as u32,
+                        CPUAccessFlags: D3D11_CPU_ACCESS_WRITE.0 as u32,
                         MiscFlags: 0,
                         StructureByteStride: 0,
                     },
-                    null_mut(),
+                    None,
+                    Some(&mut buf),
                 )
                 .expect("CreateBuffer")
-        }
+        };
+        buf.unwrap()
     }
 
     fn vtx_buffer(&self) -> ID3D11Buffer {
@@ -497,7 +505,8 @@ impl Texture {
         let texture = fonts.build_rgba32_texture();
         let data = texture.data.to_vec();
 
-        let tex = unsafe {
+        let mut tex = None;
+        unsafe {
             dasc.dev().CreateTexture2D(
                 &D3D11_TEXTURE2D_DESC {
                     Width: texture.width as _,
@@ -507,42 +516,55 @@ impl Texture {
                     Format: DXGI_FORMAT_R8G8B8A8_UNORM,
                     SampleDesc: DXGI_SAMPLE_DESC { Count: 1, Quality: 0 },
                     Usage: D3D11_USAGE_DEFAULT,
-                    BindFlags: D3D11_BIND_SHADER_RESOURCE,
-                    CPUAccessFlags: D3D11_CPU_ACCESS_FLAG(0),
-                    MiscFlags: D3D11_RESOURCE_MISC_FLAG(0),
+                    BindFlags: D3D11_BIND_SHADER_RESOURCE.0 as u32,
+                    CPUAccessFlags: 0, // D3D11_CPU_ACCESS_FLAG(0),
+                    MiscFlags: 0,      // D3D11_RESOURCE_MISC_FLAG(0),
                 } as *const _,
-                &D3D11_SUBRESOURCE_DATA {
+                Some(&D3D11_SUBRESOURCE_DATA {
                     pSysMem: data.as_ptr() as _,
                     SysMemPitch: texture.width * 4,
                     SysMemSlicePitch: 0,
-                } as *const _,
+                }),
+                Some(&mut tex),
             )?
         };
+        let tex = tex.unwrap();
 
-        let tex_view = unsafe {
-            dasc.dev().CreateShaderResourceView(&tex, &D3D11_SHADER_RESOURCE_VIEW_DESC {
-                Format: DXGI_FORMAT_R8G8B8A8_UNORM,
-                ViewDimension: D3D11_SRV_DIMENSION_TEXTURE2D,
-                Anonymous: D3D11_SHADER_RESOURCE_VIEW_DESC_0 {
-                    Texture2D: D3D11_TEX2D_SRV { MostDetailedMip: 0, MipLevels: 1 },
+        let mut tex_view = None;
+        unsafe {
+            dasc.dev().CreateShaderResourceView(
+                &tex,
+                Some(&D3D11_SHADER_RESOURCE_VIEW_DESC {
+                    Format: DXGI_FORMAT_R8G8B8A8_UNORM,
+                    ViewDimension: D3D11_SRV_DIMENSION_TEXTURE2D,
+                    Anonymous: D3D11_SHADER_RESOURCE_VIEW_DESC_0 {
+                        Texture2D: D3D11_TEX2D_SRV { MostDetailedMip: 0, MipLevels: 1 },
+                    },
+                }),
+                Some(&mut tex_view),
+            )?
+        };
+        let tex_view = tex_view.unwrap();
+
+        let mut _font_sampler = None;
+        unsafe {
+            dasc.dev().CreateSamplerState(
+                &D3D11_SAMPLER_DESC {
+                    Filter: D3D11_FILTER_MIN_MAG_MIP_LINEAR,
+                    AddressU: D3D11_TEXTURE_ADDRESS_WRAP,
+                    AddressV: D3D11_TEXTURE_ADDRESS_WRAP,
+                    AddressW: D3D11_TEXTURE_ADDRESS_WRAP,
+                    MipLODBias: 0.,
+                    ComparisonFunc: D3D11_COMPARISON_ALWAYS,
+                    MinLOD: 0.,
+                    MaxLOD: 0.,
+                    BorderColor: [0.; 4],
+                    MaxAnisotropy: 0,
                 },
-            } as *const _)?
+                Some(&mut _font_sampler),
+            )?
         };
-
-        let _font_sampler = unsafe {
-            dasc.dev().CreateSamplerState(&D3D11_SAMPLER_DESC {
-                Filter: D3D11_FILTER_MIN_MAG_MIP_LINEAR,
-                AddressU: D3D11_TEXTURE_ADDRESS_WRAP,
-                AddressV: D3D11_TEXTURE_ADDRESS_WRAP,
-                AddressW: D3D11_TEXTURE_ADDRESS_WRAP,
-                MipLODBias: 0.,
-                ComparisonFunc: D3D11_COMPARISON_ALWAYS,
-                MinLOD: 0.,
-                MaxLOD: 0.,
-                BorderColor: [0.; 4],
-                MaxAnisotropy: 0,
-            })?
-        };
+        let _font_sampler = _font_sampler.unwrap();
 
         fonts.tex_id = imgui::TextureId::from(&tex_view as *const _ as usize);
         trace!("Texture view: {:x} id: {:x}", &tex_view as *const _ as usize, fonts.tex_id.id());
@@ -596,38 +618,43 @@ impl StateBackup {
             ..Default::default()
         };
         unsafe {
-            ctx.RSGetScissorRects(
-                &mut r.scissor_rects_count,
-                &mut r.scissor_rects as *mut _ as *mut _,
+            ctx.RSGetScissorRects(&mut r.scissor_rects_count, Some(r.scissor_rects.as_mut_ptr()));
+            ctx.RSGetViewports(&mut r.viewports_count, Some(r.viewports.as_mut_ptr()));
+            r.rasterizer_state = ctx.RSGetState().ok();
+            ctx.OMGetBlendState(
+                Some(&mut r.blend_state),
+                Some(&mut r.blend_factor),
+                Some(&mut r.sample_mask),
             );
-            ctx.RSGetViewports(&mut r.viewports_count, &mut r.viewports as *mut _ as *mut _);
-            ctx.RSGetState(&mut r.rasterizer_state);
-            ctx.OMGetBlendState(&mut r.blend_state, &mut r.blend_factor as _, &mut r.sample_mask);
-            ctx.OMGetDepthStencilState(&mut r.depth_stencil_state, &mut r.stencil_ref);
-            ctx.PSGetShaderResources(0, &mut r.ps_shader_resource);
+            ctx.OMGetDepthStencilState(Some(&mut r.depth_stencil_state), Some(&mut r.stencil_ref));
+            ctx.PSGetShaderResources(0, Some(&mut r.ps_shader_resource));
             r.ps_instances_count = 256;
             r.vs_instances_count = 256;
             ctx.PSGetShader(
                 &mut r.pixel_shader,
-                &mut r.ps_instances as *mut _,
-                &mut r.ps_instances_count,
+                Some(&mut r.ps_instances),
+                Some(&mut r.ps_instances_count),
             );
-            ctx.VSGetShader(&mut r.vertex_shader, &mut r.vs_instances, &mut r.vs_instances_count);
-            ctx.VSGetConstantBuffers(0, &mut r.vertex_constant_buffer);
-            ctx.IAGetPrimitiveTopology(&mut r.primitive_topology);
+            ctx.VSGetShader(
+                &mut r.vertex_shader,
+                Some(&mut r.vs_instances),
+                Some(&mut r.vs_instances_count),
+            );
+            ctx.VSGetConstantBuffers(0, Some(&mut r.vertex_constant_buffer));
+            r.primitive_topology = ctx.IAGetPrimitiveTopology();
             ctx.IAGetIndexBuffer(
-                &mut r.index_buffer,
-                &mut r.index_buffer_format,
-                &mut r.index_buffer_offset,
+                Some(&mut r.index_buffer),
+                Some(&mut r.index_buffer_format),
+                Some(&mut r.index_buffer_offset),
             );
             ctx.IAGetVertexBuffers(
                 0,
                 1,
-                &mut r.vertex_buffer,
-                &mut r.vertex_buffer_stride,
-                &mut r.vertex_buffer_offset,
+                Some(&mut r.vertex_buffer),
+                Some(&mut r.vertex_buffer_stride),
+                Some(&mut r.vertex_buffer_offset),
             );
-            ctx.IAGetInputLayout(&mut r.input_layout);
+            r.input_layout = ctx.IAGetInputLayout().ok();
         }
 
         r
@@ -635,22 +662,22 @@ impl StateBackup {
 
     fn restore(self, ctx: ID3D11DeviceContext) {
         unsafe {
-            ctx.RSSetScissorRects(&self.scissor_rects);
-            ctx.RSSetViewports(&self.viewports);
+            ctx.RSSetScissorRects(Some(&self.scissor_rects));
+            ctx.RSSetViewports(Some(&self.viewports));
             ctx.RSSetState(self.rasterizer_state.as_ref());
             ctx.OMSetBlendState(
                 self.blend_state.as_ref(),
-                &self.blend_factor as _,
+                Some(&self.blend_factor),
                 self.sample_mask,
             );
             ctx.OMSetDepthStencilState(self.depth_stencil_state.as_ref(), self.stencil_ref);
-            ctx.PSSetShaderResources(0, &self.ps_shader_resource);
+            ctx.PSSetShaderResources(0, Some(&self.ps_shader_resource));
             // ctx.PSSetSamplers(0, &[self.ps_sampler]);
             if self.ps_instances.is_some() {
-                ctx.PSSetShader(self.pixel_shader.as_ref(), &[self.ps_instances]);
+                ctx.PSSetShader(self.pixel_shader.as_ref(), Some(&[self.ps_instances]));
             }
             if self.vs_instances.is_some() {
-                ctx.VSSetShader(self.vertex_shader.as_ref(), &[self.vs_instances]);
+                ctx.VSSetShader(self.vertex_shader.as_ref(), Some(&[self.vs_instances]));
             }
             ctx.IASetPrimitiveTopology(self.primitive_topology);
             ctx.IASetIndexBuffer(
@@ -661,9 +688,9 @@ impl StateBackup {
             ctx.IASetVertexBuffers(
                 0,
                 1,
-                &self.vertex_buffer,
-                &self.vertex_buffer_stride,
-                &self.vertex_buffer_offset,
+                Some(&self.vertex_buffer),
+                Some(&self.vertex_buffer_stride),
+                Some(&self.vertex_buffer_offset),
             );
             ctx.IASetInputLayout(self.input_layout.as_ref());
         }
@@ -731,14 +758,14 @@ impl ShaderProgram {
                 VERTEX_SHADER_SRC.as_ptr() as _,
                 VERTEX_SHADER_SRC.len(),
                 None,
-                null_mut(),
                 None,
-                PCSTR("main\0".as_ptr() as _),
-                PCSTR("vs_4_0\0".as_ptr() as _),
+                None,
+                s!("main\0"),
+                s!("vs_4_0\0"),
                 0,
                 0,
                 &mut vs_blob,
-                &mut None,
+                None,
             )?
         };
 
@@ -747,39 +774,52 @@ impl ShaderProgram {
                 PIXEL_SHADER_SRC.as_ptr() as _,
                 PIXEL_SHADER_SRC.len(),
                 None,
-                null_mut(),
                 None,
-                PCSTR("main\0".as_ptr() as _),
-                PCSTR("ps_4_0\0".as_ptr() as _),
+                None,
+                s!("main\0"),
+                s!("ps_4_0\0"),
                 0,
                 0,
                 &mut ps_blob as *mut _ as _,
-                &mut None,
+                None,
             )?
         };
 
         let vtx_shader = unsafe {
+            let mut v = None;
             let vs_blob = vs_blob.as_ref().unwrap();
             let ptr = vs_blob.GetBufferPointer();
             let size = vs_blob.GetBufferSize();
-            dasc.dev().CreateVertexShader(std::slice::from_raw_parts(ptr as _, size), None)?
+            dasc.dev().CreateVertexShader(
+                std::slice::from_raw_parts(ptr as _, size),
+                None,
+                Some(&mut v),
+            )?;
+            v.unwrap()
         };
 
         let pix_shader = unsafe {
+            let mut v = None;
             let ps_blob = ps_blob.as_ref().unwrap();
             let ptr = ps_blob.GetBufferPointer();
             let size = ps_blob.GetBufferSize();
-            dasc.dev().CreatePixelShader(std::slice::from_raw_parts(ptr as _, size), None)?
+            dasc.dev().CreatePixelShader(
+                std::slice::from_raw_parts(ptr as _, size),
+                None,
+                Some(&mut v),
+            )?;
+            v.unwrap()
         };
 
         let layout = unsafe {
+            let mut v = None;
             let vs_blob = vs_blob.as_ref().unwrap();
             let ptr = vs_blob.GetBufferPointer();
             let size = vs_blob.GetBufferSize();
             dasc.dev().CreateInputLayout(
                 &[
                     D3D11_INPUT_ELEMENT_DESC {
-                        SemanticName: PCSTR("POSITION\0".as_ptr() as _),
+                        SemanticName: s!("POSITION\0"),
                         SemanticIndex: 0,
                         Format: DXGI_FORMAT_R32G32_FLOAT,
                         InputSlot: 0,
@@ -788,7 +828,7 @@ impl ShaderProgram {
                         InstanceDataStepRate: 0,
                     },
                     D3D11_INPUT_ELEMENT_DESC {
-                        SemanticName: PCSTR("TEXCOORD\0".as_ptr() as _),
+                        SemanticName: s!("TEXCOORD\0"),
                         SemanticIndex: 0,
                         Format: DXGI_FORMAT_R32G32_FLOAT,
                         InputSlot: 0,
@@ -797,7 +837,7 @@ impl ShaderProgram {
                         InstanceDataStepRate: 0,
                     },
                     D3D11_INPUT_ELEMENT_DESC {
-                        SemanticName: PCSTR("COLOR\0".as_ptr() as _),
+                        SemanticName: s!("COLOR\0"),
                         SemanticIndex: 0,
                         Format: DXGI_FORMAT_R8G8B8A8_UNORM,
                         InputSlot: 0,
@@ -807,86 +847,108 @@ impl ShaderProgram {
                     },
                 ],
                 std::slice::from_raw_parts(ptr as _, size),
-            )?
+                Some(&mut v),
+            )?;
+            v.unwrap()
         };
 
         let sampler = unsafe {
-            dasc.dev().CreateSamplerState(&D3D11_SAMPLER_DESC {
-                Filter: D3D11_FILTER_MIN_MAG_MIP_LINEAR,
-                AddressU: D3D11_TEXTURE_ADDRESS_WRAP,
-                AddressV: D3D11_TEXTURE_ADDRESS_WRAP,
-                AddressW: D3D11_TEXTURE_ADDRESS_WRAP,
-                MipLODBias: 0.,
-                ComparisonFunc: D3D11_COMPARISON_ALWAYS,
-                MinLOD: 0.,
-                MaxLOD: 0.,
-                BorderColor: [0.; 4],
-                MaxAnisotropy: 0,
-            })?
+            let mut v = None;
+            dasc.dev().CreateSamplerState(
+                &D3D11_SAMPLER_DESC {
+                    Filter: D3D11_FILTER_MIN_MAG_MIP_LINEAR,
+                    AddressU: D3D11_TEXTURE_ADDRESS_WRAP,
+                    AddressV: D3D11_TEXTURE_ADDRESS_WRAP,
+                    AddressW: D3D11_TEXTURE_ADDRESS_WRAP,
+                    MipLODBias: 0.,
+                    ComparisonFunc: D3D11_COMPARISON_ALWAYS,
+                    MinLOD: 0.,
+                    MaxLOD: 0.,
+                    BorderColor: [0.; 4],
+                    MaxAnisotropy: 0,
+                },
+                Some(&mut v),
+            )?;
+            v.unwrap()
         };
 
         let blend_state = unsafe {
-            dasc.dev().CreateBlendState(&D3D11_BLEND_DESC {
-                AlphaToCoverageEnable: BOOL(0),
-                IndependentBlendEnable: BOOL(0),
-                RenderTarget: [
-                    D3D11_RENDER_TARGET_BLEND_DESC {
-                        BlendEnable: BOOL(1),
-                        SrcBlend: D3D11_BLEND_SRC_ALPHA,
-                        DestBlend: D3D11_BLEND_INV_SRC_ALPHA,
-                        BlendOp: D3D11_BLEND_OP_ADD,
-                        SrcBlendAlpha: D3D11_BLEND_INV_SRC_ALPHA,
-                        DestBlendAlpha: D3D11_BLEND_ZERO,
-                        BlendOpAlpha: D3D11_BLEND_OP_ADD,
-                        RenderTargetWriteMask: D3D11_COLOR_WRITE_ENABLE_ALL.0 as _,
-                    },
-                    std::mem::zeroed(),
-                    std::mem::zeroed(),
-                    std::mem::zeroed(),
-                    std::mem::zeroed(),
-                    std::mem::zeroed(),
-                    std::mem::zeroed(),
-                    std::mem::zeroed(),
-                ],
-            } as *const _)?
+            let mut v = None;
+            dasc.dev().CreateBlendState(
+                &D3D11_BLEND_DESC {
+                    AlphaToCoverageEnable: BOOL(0),
+                    IndependentBlendEnable: BOOL(0),
+                    RenderTarget: [
+                        D3D11_RENDER_TARGET_BLEND_DESC {
+                            BlendEnable: BOOL(1),
+                            SrcBlend: D3D11_BLEND_SRC_ALPHA,
+                            DestBlend: D3D11_BLEND_INV_SRC_ALPHA,
+                            BlendOp: D3D11_BLEND_OP_ADD,
+                            SrcBlendAlpha: D3D11_BLEND_INV_SRC_ALPHA,
+                            DestBlendAlpha: D3D11_BLEND_ZERO,
+                            BlendOpAlpha: D3D11_BLEND_OP_ADD,
+                            RenderTargetWriteMask: D3D11_COLOR_WRITE_ENABLE_ALL.0 as _,
+                        },
+                        std::mem::zeroed(),
+                        std::mem::zeroed(),
+                        std::mem::zeroed(),
+                        std::mem::zeroed(),
+                        std::mem::zeroed(),
+                        std::mem::zeroed(),
+                        std::mem::zeroed(),
+                    ],
+                },
+                Some(&mut v),
+            )?;
+            v.unwrap()
         };
 
         let rasterizer_state = unsafe {
-            dasc.dev().CreateRasterizerState(&D3D11_RASTERIZER_DESC {
-                FillMode: D3D11_FILL_SOLID,
-                CullMode: D3D11_CULL_NONE,
-                ScissorEnable: BOOL(1),
-                DepthClipEnable: BOOL(1),
-                DepthBias: 0,
-                DepthBiasClamp: 0.,
-                SlopeScaledDepthBias: 0.,
-                MultisampleEnable: BOOL(0),
-                AntialiasedLineEnable: BOOL(0),
-                FrontCounterClockwise: BOOL(0),
-            })?
+            let mut v = None;
+            dasc.dev().CreateRasterizerState(
+                &D3D11_RASTERIZER_DESC {
+                    FillMode: D3D11_FILL_SOLID,
+                    CullMode: D3D11_CULL_NONE,
+                    ScissorEnable: BOOL(1),
+                    DepthClipEnable: BOOL(1),
+                    DepthBias: 0,
+                    DepthBiasClamp: 0.,
+                    SlopeScaledDepthBias: 0.,
+                    MultisampleEnable: BOOL(0),
+                    AntialiasedLineEnable: BOOL(0),
+                    FrontCounterClockwise: BOOL(0),
+                },
+                Some(&mut v),
+            )?;
+            v.unwrap()
         };
 
         let depth_stencil_state = unsafe {
-            dasc.dev().CreateDepthStencilState(&D3D11_DEPTH_STENCIL_DESC {
-                DepthEnable: BOOL(0),
-                DepthFunc: D3D11_COMPARISON_ALWAYS,
-                DepthWriteMask: D3D11_DEPTH_WRITE_MASK_ALL,
-                StencilEnable: BOOL(0),
-                StencilReadMask: 0,
-                StencilWriteMask: 0,
-                FrontFace: D3D11_DEPTH_STENCILOP_DESC {
-                    StencilFailOp: D3D11_STENCIL_OP_KEEP,
-                    StencilDepthFailOp: D3D11_STENCIL_OP_KEEP,
-                    StencilPassOp: D3D11_STENCIL_OP_KEEP,
-                    StencilFunc: D3D11_COMPARISON_ALWAYS,
+            let mut v = None;
+            dasc.dev().CreateDepthStencilState(
+                &D3D11_DEPTH_STENCIL_DESC {
+                    DepthEnable: BOOL(0),
+                    DepthFunc: D3D11_COMPARISON_ALWAYS,
+                    DepthWriteMask: D3D11_DEPTH_WRITE_MASK_ALL,
+                    StencilEnable: BOOL(0),
+                    StencilReadMask: 0,
+                    StencilWriteMask: 0,
+                    FrontFace: D3D11_DEPTH_STENCILOP_DESC {
+                        StencilFailOp: D3D11_STENCIL_OP_KEEP,
+                        StencilDepthFailOp: D3D11_STENCIL_OP_KEEP,
+                        StencilPassOp: D3D11_STENCIL_OP_KEEP,
+                        StencilFunc: D3D11_COMPARISON_ALWAYS,
+                    },
+                    BackFace: D3D11_DEPTH_STENCILOP_DESC {
+                        StencilFailOp: D3D11_STENCIL_OP_KEEP,
+                        StencilDepthFailOp: D3D11_STENCIL_OP_KEEP,
+                        StencilPassOp: D3D11_STENCIL_OP_KEEP,
+                        StencilFunc: D3D11_COMPARISON_ALWAYS,
+                    },
                 },
-                BackFace: D3D11_DEPTH_STENCILOP_DESC {
-                    StencilFailOp: D3D11_STENCIL_OP_KEEP,
-                    StencilDepthFailOp: D3D11_STENCIL_OP_KEEP,
-                    StencilPassOp: D3D11_STENCIL_OP_KEEP,
-                    StencilFunc: D3D11_COMPARISON_ALWAYS,
-                },
-            })?
+                Some(&mut v),
+            )?;
+            v.unwrap()
         };
 
         Ok(ShaderProgram {
@@ -901,11 +963,11 @@ impl ShaderProgram {
     }
 
     unsafe fn set_state(&self, dasc: &DeviceAndSwapChain) {
-        dasc.dev_ctx().VSSetShader(&self.vtx_shader, &[]);
-        dasc.dev_ctx().PSSetShader(&self.pix_shader, &[]);
+        dasc.dev_ctx().VSSetShader(&self.vtx_shader, Some(&[]));
+        dasc.dev_ctx().PSSetShader(&self.pix_shader, Some(&[]));
         dasc.dev_ctx().IASetInputLayout(&self.layout);
-        dasc.dev_ctx().PSSetSamplers(0, &[Some(self.sampler.clone())]);
-        dasc.dev_ctx().OMSetBlendState(&self.blend_state, &[0f32; 4] as _, 0xFFFFFFFF);
+        dasc.dev_ctx().PSSetSamplers(0, Some(&[Some(self.sampler.clone())]));
+        dasc.dev_ctx().OMSetBlendState(&self.blend_state, Some(&[0f32; 4]), 0xFFFFFFFF);
         dasc.dev_ctx().OMSetDepthStencilState(&self.depth_stencil_state, 0);
         dasc.dev_ctx().RSSetState(&self.rasterizer_state);
     }

--- a/src/renderers/imgui_dx12.rs
+++ b/src/renderers/imgui_dx12.rs
@@ -79,12 +79,12 @@ impl RenderEngine {
                 display_pos[1] + display_size[1],
             ];
 
-            [
-                [2. / (r - l), 0., 0., 0.],
-                [0., 2. / (t - b), 0., 0.],
-                [0., 0., 0.5, 0.],
-                [(r + l) / (l - r), (t + b) / (b - t), 0.5, 1.0],
-            ]
+            [[2. / (r - l), 0., 0., 0.], [0., 2. / (t - b), 0., 0.], [0., 0., 0.5, 0.], [
+                (r + l) / (l - r),
+                (t + b) / (b - t),
+                0.5,
+                1.0,
+            ]]
         };
 
         trace!("Display size {}x{}", display_size[0], display_size[1]);

--- a/src/renderers/imgui_dx9.rs
+++ b/src/renderers/imgui_dx9.rs
@@ -395,6 +395,7 @@ impl Renderer {
     ) -> Result<(IDirect3DVertexBuffer9, usize)> {
         let len = vtx_count + VERTEX_BUF_ADD_CAPACITY;
         let mut vertex_buffer: Option<IDirect3DVertexBuffer9> = None;
+
         device.CreateVertexBuffer(
             (len * mem::size_of::<CustomVertex>()) as u32,
             (D3DUSAGE_DYNAMIC | D3DUSAGE_WRITEONLY) as u32,

--- a/src/renderers/imgui_opengl3.rs
+++ b/src/renderers/imgui_opengl3.rs
@@ -1,7 +1,7 @@
 use std::ffi::{c_void, CString};
 use std::sync::OnceLock;
 
-use windows::core::PCSTR;
+use windows::core::{s, PCSTR};
 use windows::Win32::Foundation::{FARPROC, HINSTANCE};
 use windows::Win32::Graphics::OpenGL::wglGetProcAddress;
 use windows::Win32::System::LibraryLoader::{GetProcAddress, LoadLibraryA};
@@ -9,9 +9,7 @@ use windows::Win32::System::LibraryLoader::{GetProcAddress, LoadLibraryA};
 static OPENGL3_LIB: OnceLock<HINSTANCE> = OnceLock::new();
 
 unsafe fn get_opengl3_lib() -> HINSTANCE {
-    let opengl3_cstring = CString::new("opengl32.dll").unwrap();
-
-    LoadLibraryA(PCSTR(opengl3_cstring.as_ptr() as _)).unwrap()
+    LoadLibraryA(s!("opengl32.dll\0")).expect("LoadLibraryA").into()
 }
 
 /// # Safety

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,22 @@
+pub fn try_out_param<T, F, E, O>(mut f: F) -> Result<T, E>
+where
+    T: Default,
+    F: FnMut(&mut T) -> Result<O, E>,
+{
+    let mut t: T = Default::default();
+    match f(&mut t) {
+        Ok(_) => Ok(t),
+        Err(e) => Err(e),
+    }
+}
+
+pub fn try_out_ptr<T, F, E, O>(mut f: F) -> Result<T, E>
+where
+    F: FnMut(&mut Option<T>) -> Result<O, E>,
+{
+    let mut t: Option<T> = None;
+    match f(&mut t) {
+        Ok(_) => Ok(t.unwrap()),
+        Err(e) => Err(e),
+    }
+}

--- a/tests/harness/dx9.rs
+++ b/tests/harness/dx9.rs
@@ -8,12 +8,11 @@ use std::thread::{self, JoinHandle};
 use windows::core::PCSTR;
 use windows::Win32::Foundation::{BOOL, HWND, LPARAM, LRESULT, RECT, WPARAM};
 use windows::Win32::Graphics::Direct3D9::{
-    Direct3DCreate9, D3DADAPTER_DEFAULT, D3DCREATE_SOFTWARE_VERTEXPROCESSING, D3DDEVTYPE_HAL,
-    D3DPRESENT_PARAMETERS, D3DSWAPEFFECT_DISCARD, D3D_SDK_VERSION,
+    Direct3DCreate9, D3DADAPTER_DEFAULT, D3DCLEAR_TARGET, D3DCREATE_SOFTWARE_VERTEXPROCESSING,
+    D3DDEVTYPE_HAL, D3DPRESENT_PARAMETERS, D3DSWAPEFFECT_DISCARD, D3D_SDK_VERSION,
 };
 use windows::Win32::Graphics::Gdi::HBRUSH;
 use windows::Win32::System::LibraryLoader::GetModuleHandleA;
-use windows::Win32::System::SystemServices::D3DCLEAR_TARGET;
 use windows::Win32::UI::WindowsAndMessaging::{
     AdjustWindowRect, CreateWindowExA, DefWindowProcA, DispatchMessageA, GetMessageA,
     PostQuitMessage, RegisterClassA, SetTimer, TranslateMessage, CS_HREDRAW, CS_OWNDC, CS_VREDRAW,
@@ -41,7 +40,7 @@ impl Dx9Harness {
                 let wnd_class = WNDCLASSA {
                     style: CS_OWNDC | CS_HREDRAW | CS_VREDRAW,
                     lpfnWndProc: Some(window_proc),
-                    hInstance: hinstance,
+                    hInstance: hinstance.into(),
                     lpszClassName: PCSTR("MyClass\0".as_ptr()),
                     cbClsExtra: 0,
                     cbWndExtra: 0,
@@ -69,7 +68,7 @@ impl Dx9Harness {
                         HWND(0),
                         HMENU(0),
                         hinstance,
-                        null(),
+                        None,
                     )
                 };
 

--- a/tests/harness/opengl3.rs
+++ b/tests/harness/opengl3.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use std::thread::{self, JoinHandle};
 
 use tracing::trace;
-use windows::core::PCSTR;
+use windows::core::{s, PCSTR};
 use windows::Win32::Foundation::{BOOL, HWND, LPARAM, LRESULT, RECT, WPARAM};
 use windows::Win32::Graphics::Gdi::{GetDC, HBRUSH};
 use windows::Win32::Graphics::OpenGL::{
@@ -42,8 +42,8 @@ impl Opengl3Harness {
                 let wnd_class = WNDCLASSA {
                     style: CS_OWNDC | CS_HREDRAW | CS_VREDRAW,
                     lpfnWndProc: Some(window_proc),
-                    hInstance: hinstance,
-                    lpszClassName: PCSTR("MyClass\0".as_ptr()),
+                    hInstance: hinstance.into(),
+                    lpszClassName: s!("MyClass\0"),
                     cbClsExtra: 0,
                     cbWndExtra: 0,
                     hIcon: HICON::default(),
@@ -70,7 +70,7 @@ impl Opengl3Harness {
                         HWND::default(),  // hWndParent
                         HMENU::default(), // hMenu
                         hinstance,        // hInstance
-                        null(),
+                        None,
                     )
                 }; // lpParam
 
@@ -96,7 +96,7 @@ impl Opengl3Harness {
                     cDepthBits: 24,
                     cStencilBits: 8,
                     cAuxBuffers: 0,
-                    iLayerType: PFD_MAIN_PLANE,
+                    iLayerType: PFD_MAIN_PLANE.0 as u8,
                     bReserved: 0,
                     dwLayerMask: 0,
                     dwVisibleMask: 0,

--- a/tests/hook.rs
+++ b/tests/hook.rs
@@ -6,7 +6,7 @@ pub struct HookExample;
 impl HookExample {
     pub fn new() -> Self {
         println!("Initializing");
-        hudhook::alloc_console();
+        hudhook::alloc_console().ok();
 
         HookExample
     }


### PR DESCRIPTION
This PR bumps `windows-rs` to the latest 0.51 version.

There are some new patterns to deal with optional out params that `windows` isn't handling in a very elegant way, e.g. options of options of mutable pointers where the difference between `None` and `Some(null_mut())` is not particularly evident, so some helper functions to deal with these cases should be added and applied:

- `out_param` for pre-allocated out parameters
- `try_out_param` for pre-allocated out parameters in a fallible function
- `out_ptr` for out pointers allocated by the function itself
- `try_out_ptr` for out pointers allocated by a fallible function

Example of usage:

```rust
let desc = try_out_param(|&mut out| device_and_swap_chain.GetDesc(out))?;
```

Blocked by #126 