### PR TITLE
Avoid calls to `RoOriginateErrorW`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hudhook"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 description = "A graphics API hook with dear imgui render loop. Supports DirectX 9, 11, 12, and OpenGL 3."
 homepage = "https://github.com/veeenu/hudhook"

--- a/src/hooks/dx11.rs
+++ b/src/hooks/dx11.rs
@@ -48,7 +48,8 @@ unsafe fn init_pipeline(swap_chain: &IDXGISwapChain) -> Result<Mutex<Pipeline<D3
     let engine = D3D11RenderEngine::new(&swap_chain.GetDevice()?, &mut ctx)?;
 
     let Some(render_loop) = RENDER_LOOP.take() else {
-        return Err(Error::new(HRESULT(-1), "Render loop not yet initialized"));
+        error!("Render loop not yet initialized");
+        return Err(Error::from_hresult(HRESULT(-1)));
     };
 
     let pipeline = Pipeline::new(hwnd, ctx, engine, render_loop).map_err(|(e, render_loop)| {
@@ -64,7 +65,8 @@ fn render(swap_chain: &IDXGISwapChain) -> Result<()> {
         let pipeline = PIPELINE.get_or_try_init(|| init_pipeline(swap_chain))?;
 
         let Some(mut pipeline) = pipeline.try_lock() else {
-            return Err(Error::new(HRESULT(-1), "Could not lock pipeline"));
+            error!("Could not lock pipeline");
+            return Err(Error::from_hresult(HRESULT(-1)));
         };
 
         pipeline.prepare_render()?;

--- a/src/hooks/dx12.rs
+++ b/src/hooks/dx12.rs
@@ -64,7 +64,8 @@ unsafe fn init_pipeline(
     swap_chain: &IDXGISwapChain3,
 ) -> Result<Mutex<Pipeline<D3D12RenderEngine>>> {
     let Some(command_queue) = COMMAND_QUEUE.get() else {
-        return Err(Error::new(HRESULT(-1), "Command queue not yet initialized"));
+        error!("Command queue not yet initialized");
+        return Err(Error::from_hresult(HRESULT(-1)));
     };
 
     let hwnd = util::try_out_param(|v| swap_chain.GetDesc(v)).map(|desc| desc.OutputWindow)?;
@@ -73,7 +74,8 @@ unsafe fn init_pipeline(
     let engine = D3D12RenderEngine::new(command_queue, &mut ctx)?;
 
     let Some(render_loop) = RENDER_LOOP.take() else {
-        return Err(Error::new(HRESULT(-1), "Render loop not yet initialized"));
+        error!("Render loop not yet initialized");
+        return Err(Error::from_hresult(HRESULT(-1)));
     };
 
     let pipeline = Pipeline::new(hwnd, ctx, engine, render_loop).map_err(|(e, render_loop)| {
@@ -89,7 +91,8 @@ fn render(swap_chain: &IDXGISwapChain3) -> Result<()> {
         let pipeline = PIPELINE.get_or_try_init(|| init_pipeline(swap_chain))?;
 
         let Some(mut pipeline) = pipeline.try_lock() else {
-            return Err(Error::new(HRESULT(-1), "Could not lock pipeline"));
+            error!("Could not lock pipeline");
+            return Err(Error::from_hresult(HRESULT(-1)));
         };
 
         pipeline.prepare_render()?;

--- a/src/hooks/dx9.rs
+++ b/src/hooks/dx9.rs
@@ -54,7 +54,8 @@ unsafe fn init_pipeline(device: &IDirect3DDevice9) -> Result<Mutex<Pipeline<D3D9
     let engine = D3D9RenderEngine::new(device, &mut ctx)?;
 
     let Some(render_loop) = RENDER_LOOP.take() else {
-        return Err(Error::new(HRESULT(-1), "Render loop not yet initialized"));
+        error!("Render loop not yet initialized");
+        return Err(Error::from_hresult(HRESULT(-1)));
     };
 
     trace!("creating pipeline");
@@ -69,7 +70,8 @@ fn render(device: &IDirect3DDevice9) -> Result<()> {
     let pipeline = unsafe { PIPELINE.get_or_try_init(|| init_pipeline(device)) }?;
 
     let Some(mut pipeline) = pipeline.try_lock() else {
-        return Err(Error::new(HRESULT(-1), "Could not lock pipeline"));
+        error!("Could not lock pipeline");
+        return Err(Error::from_hresult(HRESULT(-1)));
     };
 
     pipeline.prepare_render()?;

--- a/src/hooks/opengl3.rs
+++ b/src/hooks/opengl3.rs
@@ -33,7 +33,8 @@ unsafe fn init_pipeline(dc: HDC) -> Result<Mutex<Pipeline<OpenGl3RenderEngine>>>
     let engine = OpenGl3RenderEngine::new(&mut ctx)?;
 
     let Some(render_loop) = RENDER_LOOP.take() else {
-        return Err(Error::new(HRESULT(-1), "Render loop not yet initialized"));
+        error!("Render loop not yet initialized");
+        return Err(Error::from_hresult(HRESULT(-1)));
     };
 
     let pipeline = Pipeline::new(hwnd, ctx, engine, render_loop).map_err(|(e, render_loop)| {
@@ -49,7 +50,8 @@ fn render(dc: HDC) -> Result<()> {
         let pipeline = PIPELINE.get_or_try_init(|| init_pipeline(dc))?;
 
         let Some(mut pipeline) = pipeline.try_lock() else {
-            return Err(Error::new(HRESULT(-1), "Could not lock pipeline"));
+            error!("Could not lock pipeline");
+            return Err(Error::from_hresult(HRESULT(-1)));
         };
 
         pipeline.prepare_render()?;

--- a/src/inject.rs
+++ b/src/inject.rs
@@ -118,11 +118,7 @@ unsafe fn get_process_by_title32(title: &str) -> Result<HANDLE> {
     let hwnd = FindWindowA(None, PCSTR(title.as_encoded_bytes().as_ptr()));
 
     if hwnd.0 == 0 {
-        let last_error = Error::from_win32();
-        return Err(Error::new(
-            last_error.code(),
-            format!("FindWindowA returned NULL: {:?}", last_error),
-        ));
+        return Err(Error::from_win32());
     }
 
     let mut pid: u32 = 0;
@@ -137,11 +133,7 @@ unsafe fn get_process_by_title64(title: &str) -> Result<HANDLE> {
     let hwnd = FindWindowW(None, PCWSTR(title.as_ptr()));
 
     if hwnd.0 == 0 {
-        let last_error = Error::from_win32();
-        return Err(Error::new(
-            last_error.code(),
-            format!("FindWindowW returned NULL: {:?}", last_error),
-        ));
+        return Err(Error::from_win32());
     }
 
     let mut pid: u32 = 0;
@@ -172,7 +164,7 @@ unsafe fn get_process_by_name32(name_str: &str) -> Result<HANDLE> {
 
     if Process32First(snapshot, &mut pe32).is_err() {
         CloseHandle(snapshot)?;
-        return Err(Error::new(Error::from_win32().code(), "Process32First failed"));
+        return Err(Error::from_win32());
     }
 
     let pid = loop {
@@ -185,7 +177,7 @@ unsafe fn get_process_by_name32(name_str: &str) -> Result<HANDLE> {
 
         if Process32Next(snapshot, &mut pe32).is_err() {
             CloseHandle(snapshot)?;
-            break Err(Error::new(HRESULT(0), format!("Process {name_str} not found")));
+            break Err(Error::from_hresult(HRESULT(-1)));
         }
     }?;
 
@@ -204,7 +196,7 @@ unsafe fn get_process_by_name64(name_str: &str) -> Result<HANDLE> {
 
     if Process32FirstW(snapshot, &mut pe32).is_err() {
         CloseHandle(snapshot)?;
-        return Err(Error::new(Error::from_win32().code(), "Process32First failed"));
+        return Err(Error::from_win32());
     }
 
     let pid = loop {
@@ -217,7 +209,7 @@ unsafe fn get_process_by_name64(name_str: &str) -> Result<HANDLE> {
 
         if Process32NextW(snapshot, &mut pe32).is_err() {
             CloseHandle(snapshot)?;
-            break Err(Error::new(HRESULT(0), format!("Process {name_str} not found")));
+            break Err(Error::from_hresult(HRESULT(-1)));
         }
     }?;
 

--- a/src/renderer/pipeline.rs
+++ b/src/renderer/pipeline.rs
@@ -125,7 +125,7 @@ impl<T: RenderEngine> Pipeline<T> {
 
         if (w * fsw) <= 0.0 || (h * fsh) <= 0.0 {
             error!("Insufficient display size: {w}x{h}");
-            return Err(Error::new(HRESULT(-1), "Insufficient display size"));
+            return Err(Error::from_hresult(HRESULT(-1)));
         }
 
         let ui = self.ctx.frame();


### PR DESCRIPTION
As per https://github.com/microsoft/windows-rs/issues/1287, instantiating a `windows::core::Error` calls `RoOriginateErrorW` when a message is passed in. This is not available at the moment on Wine.

Since now Wine compatibility is an explicit goal, this PR removes those calls. Running the library at all at the cost of slightly more opaque errors is a reasonable tradeoff.