### PR TITLE
Remove platform block in build.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hudhook"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 description = "A graphics API hook with dear imgui render loop. Supports DirectX 9, 11, 12, and OpenGL 3."
 homepage = "https://github.com/veeenu/hudhook"
@@ -10,8 +10,13 @@ license-file = "LICENSE"
 authors = ["Andrea Venuta <venutawebdesign@gmail.com>"]
 
 [package.metadata.docs.rs]
-default-target = "x86_64-pc-windows-msvc"
-targets = ["x86_64-pc-windows-msvc", "i686-pc-windows-msvc"]
+default-target = "x86_64-pc-windows-gnu"
+targets = [
+  "x86_64-pc-windows-msvc",
+  "i686-pc-windows-msvc", 
+  "x86_64-pc-windows-gnu", 
+  "i686-pc-windows-gnu"
+]
 
 [features]
 default = ["dx9", "dx11", "dx12", "opengl3", "inject"]

--- a/build.rs
+++ b/build.rs
@@ -8,11 +8,6 @@ fn main() {
 
     let parts = target.splitn(4, '-').collect::<Vec<_>>();
     let arch = parts[0];
-    let sys = parts[2];
-
-    if sys != "windows" {
-        panic!("Platform '{sys}' not supported.");
-    }
 
     let hde = match arch {
         "i686" => "hde/hde32.c",


### PR DESCRIPTION
`hudhook` now compiles with `x86_64-pc-windows-gnu` as well, so the platform requirement in `build.rs` is no longer useful.