### PR TITLE
Add proper cleanup to Pipeline

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hudhook"
-version = "0.6.3"
+version = "0.6.4"
 edition = "2021"
 description = "A graphics API hook with dear imgui render loop. Supports DirectX 9, 11, 12, and OpenGL 3."
 homepage = "https://github.com/veeenu/hudhook"

--- a/src/hooks/dx11.rs
+++ b/src/hooks/dx11.rs
@@ -189,7 +189,7 @@ impl Hooks for ImguiDx11Hooks {
 
     unsafe fn unhook(&mut self) {
         TRAMPOLINES.take();
-        PIPELINE.take();
+        PIPELINE.take().map(|p| p.into_inner().take());
         RENDER_LOOP.take(); // should already be null
     }
 }

--- a/src/hooks/dx12.rs
+++ b/src/hooks/dx12.rs
@@ -300,7 +300,7 @@ impl Hooks for ImguiDx12Hooks {
 
     unsafe fn unhook(&mut self) {
         TRAMPOLINES.take();
-        PIPELINE.take();
+        PIPELINE.take().map(|p| p.into_inner().take());
         COMMAND_QUEUE.take();
         RENDER_LOOP.take(); // should already be null
     }

--- a/src/hooks/dx9.rs
+++ b/src/hooks/dx9.rs
@@ -205,7 +205,7 @@ impl Hooks for ImguiDx9Hooks {
 
     unsafe fn unhook(&mut self) {
         TRAMPOLINES.take();
-        PIPELINE.take();
+        PIPELINE.take().map(|p| p.into_inner().take());
         RENDER_LOOP.take();
     }
 }

--- a/src/hooks/opengl3.rs
+++ b/src/hooks/opengl3.rs
@@ -143,7 +143,7 @@ impl Hooks for ImguiOpenGl3Hooks {
 
     unsafe fn unhook(&mut self) {
         TRAMPOLINES.take();
-        PIPELINE.take();
+        PIPELINE.take().map(|p| p.into_inner().take());
         RENDER_LOOP.take();
     }
 }


### PR DESCRIPTION
This fixes a bug where `Pipeline::cleanup` is not actually invoked in `eject`, resulting in the window procedure not being reverted.