### PR TITLE
Refactor input to use non-deprecated imgui key i/o system

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,8 +14,7 @@ jobs:
 
       - name: Install Rust toolchain
         run: |
-          rustup toolchain install nightly --profile minimal -c rustfmt,clippy
-          rustup target add i686-pc-windows-msvc --toolchain nightly
+          rustup toolchain install nightly --target x86_64-pc-windows-msvc,i686-pc-windows-msvc --profile minimal -c rustfmt,clippy
 
       - name: Format
         run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hudhook"
-version = "0.6.4"
+version = "0.6.5"
 edition = "2021"
 description = "A graphics API hook with dear imgui render loop. Supports DirectX 9, 11, 12, and OpenGL 3."
 homepage = "https://github.com/veeenu/hudhook"

--- a/src/renderer/keys.rs
+++ b/src/renderer/keys.rs
@@ -1,4 +1,5 @@
 use imgui::Key;
+use once_cell::sync::Lazy;
 use windows::Win32::UI::Input::KeyboardAndMouse::{
     VIRTUAL_KEY, VK_0, VK_1, VK_2, VK_3, VK_4, VK_5, VK_6, VK_7, VK_8, VK_9, VK_A, VK_ADD, VK_B,
     VK_BACK, VK_C, VK_CAPITAL, VK_D, VK_DECIMAL, VK_DELETE, VK_DIVIDE, VK_DOWN, VK_E, VK_END,
@@ -167,3 +168,16 @@ pub(crate) const KEYS: [(Key, VIRTUAL_KEY); 132] = [
     // (Key::GamepadL3),
     // (Key::GamepadR3),
 ];
+
+static VK_TO_IMGUI: Lazy<[Option<Key>; 256]> = Lazy::new(|| {
+    let mut map = [None; 256];
+    for (k, vk) in KEYS {
+        map[vk.0 as usize] = Some(k);
+    }
+
+    map
+});
+
+pub(crate) fn vk_to_imgui(virtual_key: VIRTUAL_KEY) -> Option<Key> {
+    VK_TO_IMGUI[virtual_key.0 as usize]
+}

--- a/src/renderer/pipeline.rs
+++ b/src/renderer/pipeline.rs
@@ -15,7 +15,7 @@ use windows::Win32::UI::WindowsAndMessaging::{
 };
 
 use crate::renderer::input::{imgui_wnd_proc_impl, WndProcType};
-use crate::renderer::{keys, RenderEngine};
+use crate::renderer::RenderEngine;
 use crate::{util, ImguiRenderLoop};
 
 type RenderLoop = Box<dyn ImguiRenderLoop + Send + Sync>;
@@ -109,10 +109,6 @@ impl<T: RenderEngine> Pipeline<T> {
 
         io.nav_active = true;
         io.nav_visible = true;
-
-        for (key, virtual_key) in keys::KEYS {
-            io[key] = virtual_key.0 as u32;
-        }
 
         self.render_loop.before_render(&mut self.ctx);
 


### PR DESCRIPTION
The system we have used so far of assigning the key map and then manually updating the `Io::keys_down` field is deprecated in `imgui`.

This PR uses the new system.