### PR TITLE
Replace texture image data

### DIFF
--- a/examples/hook_with_image.rs
+++ b/examples/hook_with_image.rs
@@ -1,6 +1,6 @@
 use std::io::Cursor;
 
-use hudhook::{ImguiRenderLoop, TextureLoader};
+use hudhook::{ImguiRenderLoop, RenderContext};
 use image::io::Reader as ImageReader;
 use image::{EncodableLayout, RgbaImage};
 use imgui::{Condition, Context, Image, TextureId};
@@ -48,8 +48,8 @@ impl Default for HookExample {
 }
 
 impl ImguiRenderLoop for HookExample {
-    fn initialize<'a>(&'a mut self, _ctx: &mut Context, texture_loader: &'a mut dyn TextureLoader) {
-        self.image_id = texture_loader
+    fn initialize<'a>(&'a mut self, _ctx: &mut Context, render_context: &'a mut dyn RenderContext) {
+        self.image_id = render_context
             .load_texture(self.image.as_bytes(), self.image.width() as _, self.image.height() as _)
             .ok();
 

--- a/examples/hook_with_image.rs
+++ b/examples/hook_with_image.rs
@@ -48,13 +48,10 @@ impl Default for HookExample {
 }
 
 impl ImguiRenderLoop for HookExample {
-    fn initialize<'a>(&'a mut self, _ctx: &mut Context, texture_loader: TextureLoader<'a>) {
-        self.image_id = texture_loader(
-            self.image.as_bytes(),
-            self.image.width() as _,
-            self.image.height() as _,
-        )
-        .ok();
+    fn initialize<'a>(&'a mut self, _ctx: &mut Context, texture_loader: &'a mut dyn TextureLoader) {
+        self.image_id = texture_loader
+            .load_texture(self.image.as_bytes(), self.image.width() as _, self.image.height() as _)
+            .ok();
 
         println!("{:?}", self.image_id);
     }

--- a/examples/support/mod.rs
+++ b/examples/support/mod.rs
@@ -68,8 +68,12 @@ impl HookExample {
 }
 
 impl ImguiRenderLoop for HookExample {
-    fn initialize<'a>(&'a mut self, _ctx: &mut imgui::Context, loader: &'a mut dyn TextureLoader) {
-        let tex_id = loader
+    fn initialize<'a>(
+        &'a mut self,
+        _ctx: &mut imgui::Context,
+        render_context: &'a mut dyn RenderContext,
+    ) {
+        let tex_id = render_context
             .load_texture(self.image.as_bytes(), self.image.width(), self.image.height())
             .unwrap();
 

--- a/examples/support/mod.rs
+++ b/examples/support/mod.rs
@@ -68,9 +68,10 @@ impl HookExample {
 }
 
 impl ImguiRenderLoop for HookExample {
-    fn initialize<'a>(&'a mut self, _ctx: &mut imgui::Context, loader: TextureLoader<'a>) {
-        let tex_id =
-            loader(self.image.as_bytes(), self.image.width(), self.image.height()).unwrap();
+    fn initialize<'a>(&'a mut self, _ctx: &mut imgui::Context, loader: &'a mut dyn TextureLoader) {
+        let tex_id = loader
+            .load_texture(self.image.as_bytes(), self.image.width(), self.image.height())
+            .unwrap();
 
         self.image_id = Some(tex_id);
     }
@@ -80,10 +81,10 @@ impl ImguiRenderLoop for HookExample {
             .size([192.0, 192.0], Condition::FirstUseEver)
             .position([16.0, 16.0], Condition::FirstUseEver)
             .build(|| {
-                Image::new(self.image_id.unwrap(), [
-                    self.image.width() as f32,
-                    self.image.height() as f32,
-                ])
+                Image::new(
+                    self.image_id.unwrap(),
+                    [self.image.width() as f32, self.image.height() as f32],
+                )
                 .build(ui);
             });
 

--- a/examples/support/mod.rs
+++ b/examples/support/mod.rs
@@ -81,10 +81,10 @@ impl ImguiRenderLoop for HookExample {
             .size([192.0, 192.0], Condition::FirstUseEver)
             .position([16.0, 16.0], Condition::FirstUseEver)
             .build(|| {
-                Image::new(
-                    self.image_id.unwrap(),
-                    [self.image.width() as f32, self.image.height() as f32],
-                )
+                Image::new(self.image_id.unwrap(), [
+                    self.image.width() as f32,
+                    self.image.height() as f32,
+                ])
                 .build(ui);
             });
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,6 +148,7 @@ pub trait RenderContext {
     /// Load texture and return TextureId to use. Invoke it in your
     /// [`crate::ImguiRenderLoop::initialize`] method for setting up textures.
     fn load_texture(&mut self, data: &[u8], width: u32, height: u32) -> Result<TextureId, Error>;
+
     /// Upload an image to an existing texture, replacing its content. Invoke it
     /// in your [`crate::ImguiRenderLoop::before_render`] method for
     /// updating textures.
@@ -232,6 +233,8 @@ pub fn eject() {
 pub trait ImguiRenderLoop {
     /// Called once at the first occurrence of the hook. Implement this to
     /// initialize your data.
+    /// `ctx` is the imgui context, and `render_context` is meant to access
+    /// hudhook renderers' extensions such as texture management.
     fn initialize<'a>(
         &'a mut self,
         _ctx: &mut Context,
@@ -241,6 +244,8 @@ pub trait ImguiRenderLoop {
 
     /// Called before rendering each frame. Use the provided `ctx` object to
     /// modify imgui settings before rendering the UI.
+    /// `ctx` is the imgui context, and `render_context` is meant to access
+    /// hudhook renderers' extensions such as texture management.
     fn before_render<'a>(
         &'a mut self,
         _ctx: &mut Context,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,8 +148,9 @@ pub trait TextureLoader {
     /// Load texture and return TextureId to use. Invoke it in your
     /// [`crate::ImguiRenderLoop::initialize`] method for setting up textures.
     fn load_texture(&mut self, data: &[u8], width: u32, height: u32) -> Result<TextureId, Error>;
-    /// Upload an image to an existing texture, replacing its content. Invoke it in your
-    /// [`crate::ImguiRenderLoop::before_render`] method for updating textures.
+    /// Upload an image to an existing texture, replacing its content. Invoke it
+    /// in your [`crate::ImguiRenderLoop::before_render`] method for
+    /// updating textures.
     fn replace_texture(
         &mut self,
         texture_id: TextureId,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,7 +144,7 @@ static mut HUDHOOK: OnceCell<Hudhook> = OnceCell::new();
 static CONSOLE_ALLOCATED: AtomicBool = AtomicBool::new(false);
 
 /// Texture Loader for ImguiRenderLoop callbacks to load and replace textures
-pub trait TextureLoader {
+pub trait RenderContext {
     /// Load texture and return TextureId to use. Invoke it in your
     /// [`crate::ImguiRenderLoop::initialize`] method for setting up textures.
     fn load_texture(&mut self, data: &[u8], width: u32, height: u32) -> Result<TextureId, Error>;
@@ -235,21 +235,21 @@ pub trait ImguiRenderLoop {
     fn initialize<'a>(
         &'a mut self,
         _ctx: &mut Context,
-        _texture_loader: &'a mut dyn TextureLoader,
+        _render_context: &'a mut dyn RenderContext,
     ) {
     }
-
-    /// Called every frame. Use the provided `ui` object to build your UI.
-    fn render(&mut self, ui: &mut Ui);
 
     /// Called before rendering each frame. Use the provided `ctx` object to
     /// modify imgui settings before rendering the UI.
     fn before_render<'a>(
         &'a mut self,
         _ctx: &mut Context,
-        _texture_loader: &'a mut dyn TextureLoader,
+        _render_context: &'a mut dyn RenderContext,
     ) {
     }
+
+    /// Called every frame. Use the provided `ui` object to build your UI.
+    fn render(&mut self, ui: &mut Ui);
 
     /// Called during the window procedure.
     fn on_wnd_proc(&self, _hwnd: HWND, _umsg: u32, _wparam: WPARAM, _lparam: LPARAM) {}

--- a/src/renderer/backend/dx11.rs
+++ b/src/renderer/backend/dx11.rs
@@ -12,7 +12,7 @@ use windows::Win32::Graphics::Direct3D11::*;
 use windows::Win32::Graphics::Dxgi::Common::*;
 
 use crate::renderer::RenderEngine;
-use crate::util;
+use crate::{util, TextureLoader};
 
 pub struct D3D11RenderEngine {
     device: ID3D11Device,
@@ -54,12 +54,23 @@ impl D3D11RenderEngine {
     }
 }
 
-impl RenderEngine for D3D11RenderEngine {
-    type RenderTarget = ID3D11Texture2D;
-
-    fn load_image(&mut self, data: &[u8], width: u32, height: u32) -> Result<imgui::TextureId> {
+impl TextureLoader for D3D11RenderEngine {
+    fn load_texture(&mut self, data: &[u8], width: u32, height: u32) -> Result<TextureId> {
         unsafe { self.texture_heap.create_texture(data, width, height) }
     }
+    fn replace_texture(
+        &mut self,
+        texture_id: TextureId,
+        data: &[u8],
+        width: u32,
+        height: u32,
+    ) -> Result<()> {
+        todo!()
+    }
+}
+
+impl RenderEngine for D3D11RenderEngine {
+    type RenderTarget = ID3D11Texture2D;
 
     fn render(
         &mut self,

--- a/src/renderer/backend/dx11.rs
+++ b/src/renderer/backend/dx11.rs
@@ -4,6 +4,7 @@ use std::{mem, ptr, slice};
 use imgui::internal::RawWrapper;
 use imgui::{BackendFlags, Context, DrawCmd, DrawData, DrawIdx, DrawVert, TextureId};
 use memoffset::offset_of;
+use tracing::error;
 use windows::core::{s, Error, Result, HRESULT};
 use windows::Win32::Foundation::RECT;
 use windows::Win32::Graphics::Direct3D::Fxc::D3DCompile;
@@ -639,13 +640,11 @@ impl TextureHeap {
     ) -> Result<()> {
         let texture = &mut self.textures[texture_id.id()];
         if texture.width != width || texture.height != height {
-            return Err(Error::new(
-                HRESULT(-1),
-                format!(
-                    "image size {width}x{height} do not match expected {}x{}",
-                    texture.width, texture.height
-                ),
-            ));
+            error!(
+                "image size {width}x{height} do not match expected {}x{}",
+                texture.width, texture.height
+            );
+            return Err(Error::from_hresult(HRESULT(-1)));
         }
 
         self.device_context.UpdateSubresource(

--- a/src/renderer/backend/dx11.rs
+++ b/src/renderer/backend/dx11.rs
@@ -12,7 +12,7 @@ use windows::Win32::Graphics::Direct3D11::*;
 use windows::Win32::Graphics::Dxgi::Common::*;
 
 use crate::renderer::RenderEngine;
-use crate::{util, TextureLoader};
+use crate::{util, RenderContext};
 
 pub struct D3D11RenderEngine {
     device: ID3D11Device,
@@ -54,7 +54,7 @@ impl D3D11RenderEngine {
     }
 }
 
-impl TextureLoader for D3D11RenderEngine {
+impl RenderContext for D3D11RenderEngine {
     fn load_texture(&mut self, data: &[u8], width: u32, height: u32) -> Result<TextureId> {
         unsafe { self.texture_heap.create_texture(data, width, height) }
     }

--- a/src/renderer/backend/dx11.rs
+++ b/src/renderer/backend/dx11.rs
@@ -4,7 +4,7 @@ use std::{mem, ptr, slice};
 use imgui::internal::RawWrapper;
 use imgui::{BackendFlags, Context, DrawCmd, DrawData, DrawIdx, DrawVert, TextureId};
 use memoffset::offset_of;
-use windows::core::{s, Result};
+use windows::core::{s, Error, Result, HRESULT};
 use windows::Win32::Foundation::RECT;
 use windows::Win32::Graphics::Direct3D::Fxc::D3DCompile;
 use windows::Win32::Graphics::Direct3D::*;
@@ -36,7 +36,7 @@ impl D3D11RenderEngine {
         let projection_buffer = Buffer::new(&device, 1, D3D11_BIND_CONSTANT_BUFFER)?;
 
         let shader_program = ShaderProgram::new(&device)?;
-        let texture_heap = TextureHeap::new(&device)?;
+        let texture_heap = TextureHeap::new(&device, &device_context)?;
 
         ctx.set_ini_filename(None);
         ctx.io_mut().backend_flags |= BackendFlags::RENDERER_HAS_VTX_OFFSET;
@@ -58,6 +58,7 @@ impl TextureLoader for D3D11RenderEngine {
     fn load_texture(&mut self, data: &[u8], width: u32, height: u32) -> Result<TextureId> {
         unsafe { self.texture_heap.create_texture(data, width, height) }
     }
+
     fn replace_texture(
         &mut self,
         texture_id: TextureId,
@@ -65,7 +66,7 @@ impl TextureLoader for D3D11RenderEngine {
         width: u32,
         height: u32,
     ) -> Result<()> {
-        todo!()
+        unsafe { self.texture_heap.update_texture(texture_id, data, width, height) }
     }
 }
 
@@ -95,14 +96,8 @@ impl RenderEngine for D3D11RenderEngine {
     fn setup_fonts(&mut self, ctx: &mut Context) -> Result<()> {
         let fonts = ctx.fonts();
         let fonts_texture = fonts.build_rgba32_texture();
-        fonts.tex_id = unsafe {
-            self.texture_heap.create_texture(
-                fonts_texture.data,
-                fonts_texture.width,
-                fonts_texture.height,
-            )
-        }?;
-
+        fonts.tex_id =
+            self.load_texture(fonts_texture.data, fonts_texture.width, fonts_texture.height)?;
         Ok(())
     }
 }
@@ -572,16 +567,23 @@ struct Texture {
     resource: ID3D11Texture2D,
     shader_resource_view: ID3D11ShaderResourceView,
     id: TextureId,
+    width: u32,
+    height: u32,
 }
 
 struct TextureHeap {
     device: ID3D11Device,
+    device_context: ID3D11DeviceContext,
     textures: Vec<Texture>,
 }
 
 impl TextureHeap {
-    fn new(device: &ID3D11Device) -> Result<Self> {
-        Ok(Self { device: device.clone(), textures: Vec::with_capacity(8) })
+    fn new(device: &ID3D11Device, device_context: &ID3D11DeviceContext) -> Result<Self> {
+        Ok(Self {
+            device: device.clone(),
+            device_context: device_context.clone(),
+            textures: Vec::with_capacity(8),
+        })
     }
 
     unsafe fn create_texture(&mut self, data: &[u8], width: u32, height: u32) -> Result<TextureId> {
@@ -623,11 +625,39 @@ impl TextureHeap {
         })?;
 
         let id = TextureId::from(self.textures.len());
-
-        let texture = Texture { resource, shader_resource_view, id };
-        self.textures.push(texture);
+        self.textures.push(Texture { resource, shader_resource_view, id, width, height });
 
         Ok(id)
+    }
+
+    unsafe fn update_texture(
+        &mut self,
+        texture_id: TextureId,
+        data: &[u8],
+        width: u32,
+        height: u32,
+    ) -> Result<()> {
+        let texture = &mut self.textures[texture_id.id()];
+        if texture.width != width || texture.height != height {
+            return Err(Error::new(
+                HRESULT(-1),
+                format!(
+                    "image size {width}x{height} do not match expected {}x{}",
+                    texture.width, texture.height
+                ),
+            ));
+        }
+
+        self.device_context.UpdateSubresource(
+            &texture.resource,
+            0,
+            None,
+            data.as_ptr() as *const c_void,
+            width * 4,
+            0,
+        );
+
+        Ok(())
     }
 }
 

--- a/src/renderer/backend/dx12.rs
+++ b/src/renderer/backend/dx12.rs
@@ -1,4 +1,4 @@
-// NOTE: see this for ManuallyDrop instanceshttps://github.com/microsoft/windows-rs/issues/2386
+// NOTE: see this for ManuallyDrop instances https://github.com/microsoft/windows-rs/issues/2386
 
 use std::ffi::c_void;
 use std::mem::ManuallyDrop;
@@ -16,6 +16,7 @@ use windows::Win32::Graphics::Dxgi::Common::*;
 
 use crate::renderer::RenderEngine;
 use crate::util::{self, Fence};
+use crate::TextureLoader;
 
 pub struct D3D12RenderEngine {
     device: ID3D12Device,
@@ -76,12 +77,23 @@ impl D3D12RenderEngine {
     }
 }
 
-impl RenderEngine for D3D12RenderEngine {
-    type RenderTarget = ID3D12Resource;
-
-    fn load_image(&mut self, data: &[u8], width: u32, height: u32) -> Result<TextureId> {
+impl TextureLoader for D3D12RenderEngine {
+    fn load_texture(&mut self, data: &[u8], width: u32, height: u32) -> Result<TextureId> {
         unsafe { self.texture_heap.create_texture(data, width, height) }
     }
+    fn replace_texture(
+        &mut self,
+        texture_id: TextureId,
+        data: &[u8],
+        width: u32,
+        height: u32,
+    ) -> Result<()> {
+        todo!()
+    }
+}
+
+impl RenderEngine for D3D12RenderEngine {
+    type RenderTarget = ID3D12Resource;
 
     fn render(&mut self, draw_data: &DrawData, render_target: Self::RenderTarget) -> Result<()> {
         unsafe {

--- a/src/renderer/backend/dx12.rs
+++ b/src/renderer/backend/dx12.rs
@@ -16,7 +16,7 @@ use windows::Win32::Graphics::Dxgi::Common::*;
 
 use crate::renderer::RenderEngine;
 use crate::util::{self, Fence};
-use crate::TextureLoader;
+use crate::RenderContext;
 
 pub struct D3D12RenderEngine {
     device: ID3D12Device,
@@ -77,7 +77,7 @@ impl D3D12RenderEngine {
     }
 }
 
-impl TextureLoader for D3D12RenderEngine {
+impl RenderContext for D3D12RenderEngine {
     fn load_texture(&mut self, data: &[u8], width: u32, height: u32) -> Result<TextureId> {
         unsafe {
             let texture_id = self.texture_heap.create_texture(width, height)?;

--- a/src/renderer/backend/dx12.rs
+++ b/src/renderer/backend/dx12.rs
@@ -7,6 +7,7 @@ use std::{mem, ptr, slice};
 use imgui::internal::RawWrapper;
 use imgui::{BackendFlags, Context, DrawCmd, DrawData, DrawIdx, DrawVert, TextureId};
 use memoffset::offset_of;
+use tracing::error;
 use windows::core::{s, w, Error, Interface, Result, HRESULT};
 use windows::Win32::Foundation::*;
 use windows::Win32::Graphics::Direct3D::Fxc::*;
@@ -795,13 +796,11 @@ impl TextureHeap {
     ) -> Result<()> {
         let texture = &self.textures[texture_id.id()];
         if texture.width != width || texture.height != height {
-            return Err(Error::new(
-                HRESULT(-1),
-                format!(
-                    "image size {width}x{height} do not match expected {}x{}",
-                    texture.width, texture.height
-                ),
-            ));
+            error!(
+                "image size {width}x{height} do not match expected {}x{}",
+                texture.width, texture.height
+            );
+            return Err(Error::from_hresult(HRESULT(-1)));
         }
 
         let upload_row_size = width * 4;

--- a/src/renderer/backend/dx9.rs
+++ b/src/renderer/backend/dx9.rs
@@ -4,6 +4,7 @@ use std::{mem, ptr};
 
 use imgui::internal::RawWrapper;
 use imgui::{BackendFlags, Context, DrawCmd, DrawData, DrawIdx, DrawVert, TextureId};
+use tracing::error;
 use windows::core::{Error, Result, HRESULT};
 use windows::Foundation::Numerics::Matrix4x4;
 use windows::Win32::Foundation::RECT;
@@ -411,13 +412,11 @@ impl TextureHeap {
     ) -> Result<()> {
         let texture = &self.textures[texture_id.id()];
         if texture.width != width || texture.height != height {
-            return Err(Error::new(
-                HRESULT(-1),
-                format!(
-                    "image size {width}x{height} do not match expected {}x{}",
-                    texture.width, texture.height
-                ),
-            ));
+            error!(
+                "image size {width}x{height} do not match expected {}x{}",
+                texture.width, texture.height
+            );
+            return Err(Error::from_hresult(HRESULT(-1)));
         }
 
         let mut r: D3DLOCKED_RECT = Default::default();

--- a/src/renderer/backend/dx9.rs
+++ b/src/renderer/backend/dx9.rs
@@ -10,7 +10,7 @@ use windows::Win32::Foundation::RECT;
 use windows::Win32::Graphics::Direct3D9::*;
 
 use crate::renderer::RenderEngine;
-use crate::{util, TextureLoader};
+use crate::{util, RenderContext};
 
 const D3DFVF_CUSTOMVERTEX: u32 = D3DFVF_XYZ | D3DFVF_DIFFUSE | D3DFVF_TEX1;
 const MAT_IDENTITY: Matrix4x4 = Matrix4x4 {
@@ -67,7 +67,7 @@ impl D3D9RenderEngine {
     }
 }
 
-impl TextureLoader for D3D9RenderEngine {
+impl RenderContext for D3D9RenderEngine {
     fn load_texture(&mut self, data: &[u8], width: u32, height: u32) -> Result<TextureId> {
         unsafe {
             let texture_id = self.texture_heap.create_texture(width, height)?;

--- a/src/renderer/backend/dx9.rs
+++ b/src/renderer/backend/dx9.rs
@@ -75,6 +75,7 @@ impl TextureLoader for D3D9RenderEngine {
             Ok(texture_id)
         }
     }
+
     fn replace_texture(
         &mut self,
         texture_id: TextureId,
@@ -108,7 +109,6 @@ impl RenderEngine for D3D9RenderEngine {
         let fonts_texture = fonts.build_rgba32_texture();
         fonts.tex_id =
             self.load_texture(fonts_texture.data, fonts_texture.width, fonts_texture.height)?;
-
         Ok(())
     }
 }
@@ -397,8 +397,7 @@ impl TextureHeap {
         })?;
 
         let id = TextureId::from(self.textures.len());
-        let texture = Texture { resource, id, width, height };
-        self.textures.push(texture);
+        self.textures.push(Texture { resource, id, width, height });
 
         Ok(id)
     }

--- a/src/renderer/backend/opengl3.rs
+++ b/src/renderer/backend/opengl3.rs
@@ -8,13 +8,13 @@ use imgui::internal::RawWrapper;
 use imgui::{Context, DrawCmd, DrawData, DrawIdx, DrawVert, TextureId};
 use memoffset::offset_of;
 use once_cell::sync::OnceCell;
-use windows::core::{s, Result, PCSTR};
+use windows::core::{s, Error, Result, HRESULT, PCSTR};
 use windows::Win32::Foundation::{FARPROC, HINSTANCE};
 use windows::Win32::Graphics::OpenGL::*;
 use windows::Win32::System::LibraryLoader::{GetProcAddress, LoadLibraryA};
 
 use crate::renderer::RenderEngine;
-use crate::util;
+use crate::{util, TextureLoader};
 
 mod gl {
     #![allow(
@@ -95,12 +95,24 @@ impl OpenGl3RenderEngine {
     }
 }
 
-impl RenderEngine for OpenGl3RenderEngine {
-    type RenderTarget = ();
-
-    fn load_image(&mut self, data: &[u8], width: u32, height: u32) -> Result<TextureId> {
+impl TextureLoader for OpenGl3RenderEngine {
+    fn load_texture(&mut self, data: &[u8], width: u32, height: u32) -> Result<TextureId> {
         unsafe { self.texture_heap.create_texture(&self.gl, data, width, height) }
     }
+
+    fn replace_texture(
+        &mut self,
+        texture_id: TextureId,
+        data: &[u8],
+        width: u32,
+        height: u32,
+    ) -> Result<()> {
+        unsafe { self.texture_heap.upload_texture(&self.gl, texture_id, data, width, height) }
+    }
+}
+
+impl RenderEngine for OpenGl3RenderEngine {
+    type RenderTarget = ();
 
     fn render(&mut self, draw_data: &DrawData, _render_target: Self::RenderTarget) -> Result<()> {
         unsafe {
@@ -173,7 +185,10 @@ impl OpenGl3RenderEngine {
                             (clip_max_y - clip_min_y) as i32,
                         );
                         self.gl.ActiveTexture(gl::TEXTURE0);
-                        self.gl.BindTexture(gl::TEXTURE_2D, cmd_params.texture_id.id() as GLuint);
+                        self.gl.BindTexture(
+                            gl::TEXTURE_2D,
+                            self.texture_heap.get(cmd_params.texture_id).gl_texture,
+                        );
 
                         self.gl.BufferData(
                             gl::ARRAY_BUFFER,
@@ -337,12 +352,21 @@ unsafe fn create_shader_program(gl: &gl::Gl) -> (GLuint, GLuint, GLuint, GLuint,
 }
 
 struct TextureHeap {
-    textures: Vec<GLuint>,
+    textures: Vec<TextureInfo>,
+}
+struct TextureInfo {
+    gl_texture: GLuint,
+    width: u32,
+    height: u32,
 }
 
 impl TextureHeap {
     fn new() -> Self {
         Self { textures: Vec::new() }
+    }
+
+    fn get(&self, texture_id: TextureId) -> &TextureInfo {
+        &self.textures[texture_id.id()]
     }
 
     unsafe fn create_texture(
@@ -375,9 +399,53 @@ impl TextureHeap {
         );
         gl.BindTexture(gl::TEXTURE_2D, bound_texture as _);
 
-        self.textures.push(texture);
+        let texture_id = self.textures.len();
 
-        Ok(TextureId::from(texture as usize))
+        self.textures.push(TextureInfo { gl_texture: texture, width, height });
+
+        Ok(TextureId::from(texture_id))
+    }
+
+    unsafe fn upload_texture(
+        &mut self,
+        gl: &gl::Gl,
+        texture: TextureId,
+        data: &[u8],
+        width: u32,
+        height: u32,
+    ) -> Result<()> {
+        let texture_info = self.get(texture);
+        if texture_info.width != width || texture_info.height != height {
+            return Result::Err(Error::new(
+                HRESULT(-1),
+                format!(
+                    "image size {width}x{height} do not match expected {}x{}",
+                    texture_info.width, texture_info.height
+                ),
+            ));
+        }
+
+        let mut bound_texture = 0;
+        gl.GetIntegerv(gl::TEXTURE_BINDING_2D, &mut bound_texture);
+
+        gl.ActiveTexture(gl::TEXTURE0);
+        gl.BindTexture(gl::TEXTURE_2D, texture_info.gl_texture);
+
+        gl.TexSubImage2D(
+            gl::TEXTURE_2D,
+            0,
+            0,
+            0,
+            width as GLint,
+            height as GLint,
+            gl::RGBA,
+            gl::UNSIGNED_BYTE,
+            data.as_ptr() as *const c_void,
+        );
+
+        gl.BindTexture(gl::TEXTURE_2D, bound_texture as _);
+
+        Ok(())
     }
 }
 

--- a/src/renderer/backend/opengl3.rs
+++ b/src/renderer/backend/opengl3.rs
@@ -14,7 +14,7 @@ use windows::Win32::Graphics::OpenGL::*;
 use windows::Win32::System::LibraryLoader::{GetProcAddress, LoadLibraryA};
 
 use crate::renderer::RenderEngine;
-use crate::{util, TextureLoader};
+use crate::{util, RenderContext};
 
 mod gl {
     #![allow(
@@ -95,7 +95,7 @@ impl OpenGl3RenderEngine {
     }
 }
 
-impl TextureLoader for OpenGl3RenderEngine {
+impl RenderContext for OpenGl3RenderEngine {
     fn load_texture(&mut self, data: &[u8], width: u32, height: u32) -> Result<TextureId> {
         unsafe { self.texture_heap.create_texture(&self.gl, data, width, height) }
     }

--- a/src/renderer/backend/opengl3.rs
+++ b/src/renderer/backend/opengl3.rs
@@ -8,6 +8,7 @@ use imgui::internal::RawWrapper;
 use imgui::{Context, DrawCmd, DrawData, DrawIdx, DrawVert, TextureId};
 use memoffset::offset_of;
 use once_cell::sync::OnceCell;
+use tracing::error;
 use windows::core::{s, Error, Result, HRESULT, PCSTR};
 use windows::Win32::Foundation::{FARPROC, HINSTANCE};
 use windows::Win32::Graphics::OpenGL::*;
@@ -408,13 +409,11 @@ impl TextureHeap {
     ) -> Result<()> {
         let texture_info = self.get(texture);
         if texture_info.width != width || texture_info.height != height {
-            return Result::Err(Error::new(
-                HRESULT(-1),
-                format!(
-                    "image size {width}x{height} do not match expected {}x{}",
-                    texture_info.width, texture_info.height
-                ),
-            ));
+            error!(
+                "image size {width}x{height} do not match expected {}x{}",
+                texture_info.width, texture_info.height
+            );
+            return Err(Error::from_hresult(HRESULT(-1)));
         }
 
         let mut bound_texture = 0;

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -7,9 +7,9 @@ mod pipeline;
 use imgui::{Context, DrawData};
 use windows::core::Result;
 
-use crate::TextureLoader;
+use crate::RenderContext;
 
-pub(crate) trait RenderEngine: TextureLoader {
+pub(crate) trait RenderEngine: RenderContext {
     type RenderTarget;
 
     fn render(&mut self, draw_data: &DrawData, render_target: Self::RenderTarget) -> Result<()>;

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -6,6 +6,7 @@ mod pipeline;
 
 use imgui::{Context, DrawData};
 use windows::core::Result;
+
 use crate::TextureLoader;
 
 pub(crate) trait RenderEngine: TextureLoader {

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -4,13 +4,13 @@ mod input;
 mod keys;
 mod pipeline;
 
-use imgui::{Context, DrawData, TextureId};
+use imgui::{Context, DrawData};
 use windows::core::Result;
+use crate::TextureLoader;
 
-pub(crate) trait RenderEngine {
+pub(crate) trait RenderEngine: TextureLoader {
     type RenderTarget;
 
-    fn load_image(&mut self, data: &[u8], width: u32, height: u32) -> Result<TextureId>;
     fn render(&mut self, draw_data: &DrawData, render_target: Self::RenderTarget) -> Result<()>;
     fn setup_fonts(&mut self, ctx: &mut Context) -> Result<()>;
 }

--- a/src/renderer/pipeline.rs
+++ b/src/renderer/pipeline.rs
@@ -58,9 +58,7 @@ impl<T: RenderEngine> Pipeline<T> {
 
         ctx.io_mut().display_size = [width as f32, height as f32];
 
-        render_loop.initialize(&mut ctx, &mut |data, width, height| {
-            engine.load_image(data, width, height)
-        });
+        render_loop.initialize(&mut ctx, &mut engine);
 
         if let Err(e) = engine.setup_fonts(&mut ctx) {
             return Err((e, render_loop));
@@ -110,7 +108,7 @@ impl<T: RenderEngine> Pipeline<T> {
         io.nav_active = true;
         io.nav_visible = true;
 
-        self.render_loop.before_render(&mut self.ctx);
+        self.render_loop.before_render(&mut self.ctx, &mut self.engine);
 
         Ok(())
     }

--- a/tests/hook.rs
+++ b/tests/hook.rs
@@ -51,11 +51,14 @@ const IMAGE_COUNT: usize = 3;
 
 pub struct HookExample {
     frame_times: Vec<Duration>,
+    first_time: Option<Instant>,
     last_time: Option<Instant>,
+    dynamic_image: DynamicImage,
     image: [RgbaImage; IMAGE_COUNT],
     image_id: [Option<TextureId>; IMAGE_COUNT],
     image_pos: [[f32; 2]; IMAGE_COUNT],
     image_vel: [[f32; 2]; IMAGE_COUNT],
+    last_upload_time: u64,
 }
 
 impl HookExample {
@@ -76,11 +79,14 @@ impl HookExample {
 
         HookExample {
             frame_times: Vec::new(),
+            first_time: None,
             last_time: None,
+            dynamic_image,
             image: [image0, image1, image2],
             image_id: [None, None, None],
             image_pos: [[16.0, 16.0], [16.0, 16.0], [16.0, 16.0]],
             image_vel: [[200.0, 200.0], [100.0, 200.0], [200.0, 100.0]],
+            last_upload_time: 0,
         }
     }
 }
@@ -92,14 +98,41 @@ impl Default for HookExample {
 }
 
 impl ImguiRenderLoop for HookExample {
-    fn initialize<'a>(&'a mut self, _ctx: &mut Context, loader: TextureLoader<'a>) {
+    fn initialize<'a>(&'a mut self, _ctx: &mut Context, loader: &'a mut dyn TextureLoader) {
         for i in 0..IMAGE_COUNT {
             let image = &self.image[i];
             self.image_id[i] =
-                loader(image.as_bytes(), image.width() as _, image.height() as _).ok();
+                loader.load_texture(image.as_bytes(), image.width() as _, image.height() as _).ok();
         }
 
         println!("{:?}", self.image_id);
+    }
+
+    fn before_render<'a>(
+        &'a mut self,
+        _ctx: &mut Context,
+        texture_loader: &'a mut dyn TextureLoader,
+    ) {
+        let elapsed = if let Some(first_time) = self.first_time {
+            first_time.elapsed().as_secs()
+        } else {
+            self.first_time = Some(Instant::now());
+            0
+        };
+        if elapsed != self.last_upload_time {
+            self.last_upload_time = elapsed;
+            self.dynamic_image.invert();
+            if let Some(texture) = self.image_id[0] {
+                texture_loader
+                    .replace_texture(
+                        texture,
+                        self.dynamic_image.as_bytes(),
+                        self.dynamic_image.width(),
+                        self.dynamic_image.height(),
+                    )
+                    .unwrap();
+            }
+        }
     }
 
     fn render(&mut self, ui: &mut imgui::Ui) {

--- a/tests/hook.rs
+++ b/tests/hook.rs
@@ -3,7 +3,7 @@ use std::io::Cursor;
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
-use hudhook::{ImguiRenderLoop, TextureLoader};
+use hudhook::{ImguiRenderLoop, RenderContext};
 use image::imageops::FilterType;
 use image::io::Reader as ImageReader;
 use image::{DynamicImage, EncodableLayout, RgbaImage};
@@ -98,11 +98,12 @@ impl Default for HookExample {
 }
 
 impl ImguiRenderLoop for HookExample {
-    fn initialize<'a>(&'a mut self, _ctx: &mut Context, loader: &'a mut dyn TextureLoader) {
+    fn initialize<'a>(&'a mut self, _ctx: &mut Context, render_context: &'a mut dyn RenderContext) {
         for i in 0..IMAGE_COUNT {
             let image = &self.image[i];
-            self.image_id[i] =
-                loader.load_texture(image.as_bytes(), image.width() as _, image.height() as _).ok();
+            self.image_id[i] = render_context
+                .load_texture(image.as_bytes(), image.width() as _, image.height() as _)
+                .ok();
         }
 
         println!("{:?}", self.image_id);
@@ -111,7 +112,7 @@ impl ImguiRenderLoop for HookExample {
     fn before_render<'a>(
         &'a mut self,
         _ctx: &mut Context,
-        texture_loader: &'a mut dyn TextureLoader,
+        render_context: &'a mut dyn RenderContext,
     ) {
         let elapsed = self.first_time.get_or_insert(Instant::now()).elapsed().as_secs();
         if elapsed != self.last_upload_time {
@@ -119,7 +120,7 @@ impl ImguiRenderLoop for HookExample {
 
             self.dynamic_image.invert();
             if let Some(texture) = self.image_id[0] {
-                texture_loader
+                render_context
                     .replace_texture(
                         texture,
                         self.dynamic_image.as_bytes(),

--- a/tests/hook.rs
+++ b/tests/hook.rs
@@ -113,14 +113,10 @@ impl ImguiRenderLoop for HookExample {
         _ctx: &mut Context,
         texture_loader: &'a mut dyn TextureLoader,
     ) {
-        let elapsed = if let Some(first_time) = self.first_time {
-            first_time.elapsed().as_secs()
-        } else {
-            self.first_time = Some(Instant::now());
-            0
-        };
+        let elapsed = self.first_time.get_or_insert(Instant::now()).elapsed().as_secs();
         if elapsed != self.last_upload_time {
             self.last_upload_time = elapsed;
+
             self.dynamic_image.invert();
             if let Some(texture) = self.image_id[0] {
                 texture_loader


### PR DESCRIPTION
Fixes #147.

1. add TextureLoader trait with load_texture and replace_texture
2. implement TextureLoader for all 4 engines
    * dx9 and dx12: load_texture = heap.create_texture + heap.upload_texture, replace_texture = heap.upload_texture
    * dx11 and gl3: load_texture = heap.create_texture (with init), replace_texture = heap.update_texture

"Allow edits by maintainers" is on. If you have any suggestions for improvement, just push changes to this branch, specially about naming and code repetition.