### PR TITLE
Bugfix panic in D3D11RenderEngine->restore

### DIFF
--- a/src/renderer/backend/dx11.rs
+++ b/src/renderer/backend/dx11.rs
@@ -821,13 +821,10 @@ impl StateBackup {
             device_context.PSSetSamplers(0, Some(&self.sampler));
         }
 
-        if self.ps_instances_count > 0
-        {
-            device_context.PSSetShader(
-                self.pixel_shader.as_ref(),
-                Some(slice::from_raw_parts(self.ps_instances, self.ps_instances_count as usize)),
-            );
-        }
+        device_context.PSSetShader(
+            self.pixel_shader.as_ref(),
+            if self.ps_instances_count > 0 { Some(slice::from_raw_parts(self.ps_instances, self.ps_instances_count as usize)) } else { None },
+        );
 
         if self.vs_instances_count > 0
         {

--- a/src/renderer/backend/dx11.rs
+++ b/src/renderer/backend/dx11.rs
@@ -823,12 +823,20 @@ impl StateBackup {
 
         device_context.PSSetShader(
             self.pixel_shader.as_ref(),
-            if self.ps_instances_count > 0 { Some(slice::from_raw_parts(self.ps_instances, self.ps_instances_count as usize)) } else { None },
+            if self.ps_instances_count > 0 {
+                Some(slice::from_raw_parts(self.ps_instances, self.ps_instances_count as usize))
+            } else {
+                None
+            },
         );
 
         device_context.VSSetShader(
             self.vertex_shader.as_ref(),
-            if self.vs_instances_count > 0 { Some(slice::from_raw_parts(self.vs_instances, self.vs_instances_count as usize)) } else { None },
+            if self.vs_instances_count > 0 {
+                Some(slice::from_raw_parts(self.vs_instances, self.vs_instances_count as usize))
+            } else { 
+                None
+            },
         );
 
         device_context.IASetVertexBuffers(

--- a/src/renderer/backend/dx11.rs
+++ b/src/renderer/backend/dx11.rs
@@ -826,13 +826,10 @@ impl StateBackup {
             if self.ps_instances_count > 0 { Some(slice::from_raw_parts(self.ps_instances, self.ps_instances_count as usize)) } else { None },
         );
 
-        if self.vs_instances_count > 0
-        {
-            device_context.VSSetShader(
-                self.vertex_shader.as_ref(),
-                Some(slice::from_raw_parts(self.vs_instances, self.vs_instances_count as usize)),
-            );
-        }
+        device_context.VSSetShader(
+            self.vertex_shader.as_ref(),
+            if self.vs_instances_count > 0 { Some(slice::from_raw_parts(self.vs_instances, self.vs_instances_count as usize)) } else { None },
+        );
 
         device_context.IASetVertexBuffers(
             0,

--- a/src/renderer/backend/dx11.rs
+++ b/src/renderer/backend/dx11.rs
@@ -821,14 +821,21 @@ impl StateBackup {
             device_context.PSSetSamplers(0, Some(&self.sampler));
         }
 
-        device_context.PSSetShader(
-            self.pixel_shader.as_ref(),
-            Some(slice::from_raw_parts(self.ps_instances, self.ps_instances_count as usize)),
-        );
-        device_context.VSSetShader(
-            self.vertex_shader.as_ref(),
-            Some(slice::from_raw_parts(self.vs_instances, self.vs_instances_count as usize)),
-        );
+        if self.ps_instances_count > 0
+        {
+            device_context.PSSetShader(
+                self.pixel_shader.as_ref(),
+                Some(slice::from_raw_parts(self.ps_instances, self.ps_instances_count as usize)),
+            );
+        }
+
+        if self.vs_instances_count > 0
+        {
+            device_context.VSSetShader(
+                self.vertex_shader.as_ref(),
+                Some(slice::from_raw_parts(self.vs_instances, self.vs_instances_count as usize)),
+            );
+        }
 
         device_context.IASetVertexBuffers(
             0,

--- a/src/renderer/backend/dx11.rs
+++ b/src/renderer/backend/dx11.rs
@@ -834,7 +834,7 @@ impl StateBackup {
             self.vertex_shader.as_ref(),
             if self.vs_instances_count > 0 {
                 Some(slice::from_raw_parts(self.vs_instances, self.vs_instances_count as usize))
-            } else { 
+            } else {
                 None
             },
         );


### PR DESCRIPTION
When self.ps_instances is none, self.ps_instances_count is 0, then slice::from_raw_parts causes a panic here.
Same for the vs version. Initially I tried this fix with is_some() but it still caused a crash for me.

I don't know if this has any side effects, for me it renders fine after this fix.