### PR TITLE
prevent crash when d3d9 render in background

### DIFF
--- a/src/renderer/backend/dx9.rs
+++ b/src/renderer/backend/dx9.rs
@@ -79,6 +79,7 @@ impl RenderContext for D3D9RenderEngine {
 
     fn replace_texture(
         &mut self,
+
         texture_id: TextureId,
         data: &[u8],
         width: u32,
@@ -90,7 +91,17 @@ impl RenderContext for D3D9RenderEngine {
 
 impl RenderEngine for D3D9RenderEngine {
     type RenderTarget = IDirect3DSurface9;
-
+    fn reset(&mut self) {
+        tracing::error!("Calling reset stuff");
+        let mut params = D3DPRESENT_PARAMETERS { ..Default::default() };
+        unsafe {
+            let result = self.device.Reset(&mut params as *mut D3DPRESENT_PARAMETERS);
+            match result {
+                Ok(_) => tracing::info!("All is good"),
+                Err(err) => tracing::error!("Error from reset: {}", err),
+            }
+        }
+    }
     fn render(
         &mut self,
         draw_data: &imgui::DrawData,

--- a/src/renderer/input.rs
+++ b/src/renderer/input.rs
@@ -339,6 +339,10 @@ pub fn imgui_wnd_proc_impl<T: RenderEngine>(
         WM_SIZE => {
             pipeline.resize(loword(lparam as u32) as u32, hiword(lparam as u32) as u32);
         },
+        WM_ACTIVATEAPP => {
+            tracing::error!("WM_ACTIVATEAPP trigered, calling reset from engine");
+            pipeline.engine.reset();
+        },
         _ => {},
     };
 

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -12,7 +12,7 @@ use crate::RenderContext;
 
 pub(crate) trait RenderEngine: RenderContext {
     type RenderTarget;
-
+    fn reset(&mut self) {}
     fn render(&mut self, draw_data: &DrawData, render_target: Self::RenderTarget) -> Result<()>;
     fn setup_fonts(&mut self, ctx: &mut Context) -> Result<()>;
 }

--- a/src/renderer/pipeline.rs
+++ b/src/renderer/pipeline.rs
@@ -41,7 +41,7 @@ pub(crate) struct PipelineSharedState {
 pub(crate) struct Pipeline<T: RenderEngine> {
     hwnd: HWND,
     ctx: Context,
-    engine: T,
+    pub engine: T,
     render_loop: RenderLoop,
     rx: Receiver<PipelineMessage>,
     shared_state: Arc<PipelineSharedState>,


### PR DESCRIPTION
I opened the issue #191  because pressing keys **ctrl+alt+supr** or **alt+tab** made my D3D9 imgui menu to disapear.

After looking at this topic: [256699-alt-tab-support-directx.html](https://www.unknowncheats.me/forum/c-and-c-/256699-alt-tab-support-directx.html), i noticed that the  WM_ACTIVATEAPP was not handled. I made a little POC that call the Reset method on the device. My menu is still present after that, even if there is rendering errors in the console.

This PR should not be merged directly