### PR TITLE
feat: add imgui features to feature table

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,9 @@ dx11 = []
 dx12 = []
 opengl3 = ["dep:gl_generator"]
 inject = []
+imgui-freetype = ["imgui/freetype"]
+imgui-docking = ["imgui/docking"]
+imgui-tables-api = ["imgui/tables-api"]
 
 [[example]]
 name = "simple_hook"


### PR DESCRIPTION
This change exposes imgui's `freetype`, `docking`, and `tables-api` features to developers under the `imgui-freetype`, `imgui-docking`, and `imgui-tables-api` features respectively.

I wanted to use the docking and the new tables api features with hudhook so I figured I should PR this here.