### PR TITLE
Check memory protection per page

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,6 +86,7 @@ features = [
   "Win32_System_Diagnostics_ToolHelp",
   "Win32_System_LibraryLoader",
   "Win32_System_Memory",
+  "Win32_System_SystemInformation",
   "Win32_System_SystemServices",
   "Win32_System_Threading",
   "Win32_UI_Input_KeyboardAndMouse",

--- a/src/util.rs
+++ b/src/util.rs
@@ -384,7 +384,7 @@ mod tests {
         assert_eq!(slice.len(), PAGE_SIZE);
 
         let slice = unsafe { readable_region::<u8>((region as usize + PAGE_SIZE) as _, 1) };
-        assert_eq!(slice.is_empty(), true);
+        assert!(slice.is_empty());
 
         let slice = unsafe { readable_region::<u8>((region as usize + PAGE_SIZE - 1) as _, 2) };
         assert_eq!(slice.len(), 1);

--- a/src/util.rs
+++ b/src/util.rs
@@ -288,8 +288,8 @@ impl Fence {
 
 /// Returns a slice of **up to** `limit` elements of type `T` starting at `ptr`.
 ///
-/// If the memory protection of some pages in this region prevents reading from it,
-/// the slice is truncated to the first `N` consecutive readable elements.
+/// If the memory protection of some pages in this region prevents reading from
+/// it, the slice is truncated to the first `N` consecutive readable elements.
 ///
 /// # Safety
 ///
@@ -321,8 +321,8 @@ pub unsafe fn readable_region<T>(ptr: *const T, limit: usize) -> &'static [T] {
     };
     let page_align_mask = page_size_bytes - 1;
 
-    // Calculate the starting address of the first and last pages that need to be readable
-    // in order to read `limit` elements of type `T` from `ptr`
+    // Calculate the starting address of the first and last pages that need to be
+    // readable in order to read `limit` elements of type `T` from `ptr`
     let first_page_addr = (ptr as usize) & !page_align_mask;
     let last_page_addr = (ptr as usize + (limit * size_of::<T>()) - 1) & !page_align_mask;
 
@@ -345,7 +345,8 @@ pub unsafe fn readable_region<T>(ptr: *const T, limit: usize) -> &'static [T] {
     }
 
     // SAFETY:
-    // - `ptr` is a valid pointer to `limit` elements of type `T` and is properly aligned
+    // - `ptr` is a valid pointer to `limit` elements of type `T` and is properly
+    //   aligned
     std::slice::from_raw_parts(ptr, limit)
 }
 


### PR DESCRIPTION
Memory protection flags are set per page so it's enough to check them at page boundaries. (See [here](https://learn.microsoft.com/en-us/windows/win32/api/memoryapi/nf-memoryapi-virtualquery#parameters))

This simplifies the code for #209 ([relevant diff](https://github.com/veeenu/hudhook/pull/209/commits/55700fdaf645d0401abe7b9f5571135697afbf76#diff-8841888df06c36a6632525a99403e18778b7de8b8efee5310396fb7b9367ef69R113-R145)) to [this](https://github.com/veeenu/hudhook/pull/210/commits/4cbabb71ad8ac35a943811d1af159839253502d3#diff-8841888df06c36a6632525a99403e18778b7de8b8efee5310396fb7b9367ef69)

I've added a helper function that checks the memory protection at each page boundary in a memory region and returns a slice containing all consecutive readable elements starting from the start of the region.

I've stared at my implementation for a bit and I *think* the logic is correct.