### PR TITLE
Fix D3DERR_INVALIDCALL returned from Present

### DIFF
--- a/src/hooks/dx12.rs
+++ b/src/hooks/dx12.rs
@@ -116,7 +116,7 @@ impl InitializationContext {
         let swap_chain_ptr = swap_chain.as_raw() as *mut *mut c_void;
         let readable_ptrs = util::readable_region(swap_chain_ptr, 512);
 
-        match readable_ptrs.iter().position(|&ptr| ptr == command_queue.as_raw()) {
+        match readable_ptrs.iter().position(|&ptr| std::ptr::eq(ptr, command_queue.as_raw())) {
             Some(idx) => {
                 debug!(
                     "Found command queue pointer in swap chain struct at offset +0x{:x}",

--- a/src/hooks/dx9.rs
+++ b/src/hooks/dx9.rs
@@ -79,10 +79,10 @@ fn render(device: &IDirect3DDevice9) -> Result<()> {
     let surface = unsafe { device.GetBackBuffer(0, 0, D3DBACKBUFFER_TYPE_MONO)? };
 
     unsafe { device.BeginScene() }?;
-    pipeline.render(surface)?;
+    let render_result = pipeline.render(surface);
     unsafe { device.EndScene() }?;
 
-    Ok(())
+    render_result
 }
 
 unsafe extern "system" fn dx9_present_impl(


### PR DESCRIPTION
Hello.

An issue was detected when using this in the latest version of <https://github.com/super-continent/ggxrd-mod>, which is an overlay mod for Guilty Gear Xrd Rev2. It is a Direct3D 9 game. When minimizing and restoring the game's window, there would be a small chance of it crashing with this error:
```
Rendering thread exception:
Result failed 
 at A:\Repo\GG-xrd-rev2-netcode\Development\Src\D3D9Drv\Src\D3D9Viewport.cpp:392 
 with error D3DERR_INVALIDCALL
```
Reverse engineering efforts pointed to an IDirect3DDevice9::Present() call returning a D3DERR_INVALIDCALL error.

Microsoft's official documentation for Direct3D 9 says:
> Present will fail, returning D3DERR_INVALIDCALL, if called between BeginScene and EndScene pairs
<https://learn.microsoft.com/en-us/windows/win32/api/d3d9/nf-d3d9-idirect3ddevice9-present>

An effort to find the mismatched `BeginScene-EndScene` pair led to code in this repository, inside `dx9.rs:fn render(device: &IDirect3DDevice9) -> Result<()>`:
```rust
    unsafe { device.BeginScene() }?;
    pipeline.render(surface)?;
    unsafe { device.EndScene() }?;
```
A `rev2mod.log` file was found inside the game's folder with the executable, `rev2mod` being the original name of the DLL compiled from <https://github.com/super-continent/ggxrd-mod> repository, and that logfile contained this error:
```
22:04:16 [ERROR] Insufficient display size: 0x0
22:04:16 [ERROR] Render error: Error { code: HRESULT(0xFFFFFFFF), message: "" }
```

This error points to this line of code in `pipeline.rs`:
```rust
        if (w * fsw) <= 0.0 || (h * fsh) <= 0.0 {
            error!("Insufficient display size: {w}x{h}");
            return Err(Error::from_hresult(HRESULT(-1)));
        }
```

Conclusion: while the game was minimized, a Present() call happened, which led to the `pipeline.rs:pub(crate) fn render(&mut self, render_target: T::RenderTarget) -> Result<()>` function returning an `Err(Error::from_hresult(HRESULT(-1)))`, which caused the `dx9.rs:fn render(device: &IDirect3DDevice9) -> Result<()>` function, which did a `BeginScene` call, to not do a corresponding call to `EndScene`, which ultimately leads to a call to the real `Present` to return D3DERR_INVALIDCALL, which causes the game to crash.

To fix this, we must ensure that a successful `BeginScene` is always accompanied by a call to `EndScene` prior to calling the real `Present`, which is the aim of this Pull Request.