### PR TITLE
Make using fences on DX12 optional via cargo feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ targets = [
 ]
 
 [features]
-default = ["dx9", "dx11", "dx12", "opengl3", "inject"]
+default = ["dx9", "dx11", "dx12", "fenced_dx12", "opengl3", "inject"]
 dx9 = []
 dx11 = []
 dx12 = []
@@ -28,6 +28,7 @@ inject = []
 imgui-freetype = ["imgui/freetype"]
 imgui-docking = ["imgui/docking"]
 imgui-tables-api = ["imgui/tables-api"]
+fenced_dx12 = []
 
 [[example]]
 name = "simple_hook"


### PR DESCRIPTION
I noticed pretty significant FPS drops in my games when injecting even the most basic hello world examples. I was able to track it down to this fence usage. As an example, in the game I am working on I get ~460FPS sitting in the town, but as soon as I inject the hello world example from the README it drops down to around ~240FPS. With this change I stick within ~10FPS of the game without injection. I didn't notice any weird synchronization issues on my game but I realize that this could potentially cause some if we remove it outright for all which is why I made it an optional feature for DX12 only and enabled it by default to retain existing functionality. 

P.S, your discord links in the readme/troubleshooting guide on all your repos has expired. :) 