### PR TITLE
fix: missing size_of import

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -3,7 +3,7 @@
 
 use std::ffi::{c_void, OsString};
 use std::fmt::Display;
-use std::mem::ManuallyDrop;
+use std::mem::{size_of, ManuallyDrop};
 use std::os::windows::ffi::OsStringExt;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};


### PR DESCRIPTION
Not sure how you managed to compile and release without this? The project was not building (The latest release on crates.io was not building for me either however v0.5 was building) this import was missing from the code. 

Edit: Ah I see this might have been added into the prelude in newer versions of Rust. I'm currently pinned on 1.75.0 for some other requirements, this is the only thing seeming to block compiling for that rust version though so couldn't hurt to merge since its just an added import