### PR TITLE
WndProc message filters for imgui input captures

### DIFF
--- a/src/renderer/msg_filter.rs
+++ b/src/renderer/msg_filter.rs
@@ -75,6 +75,11 @@ impl MessageFilter {
         match message_id {
             WM_KEYFIRST..=WM_KEYLAST => self.contains(Self::InputKeyboard),
             WM_MOUSEFIRST..=WM_MOUSELAST => self.contains(Self::InputMouse),
+            // WM_MOUSEHOVER = 0x2A1  WM_MOUSELEAVE = 0x2A3
+            0x02A1 | 0x02A3 | WM_NCMOUSEHOVER | WM_NCMOUSELEAVE | WM_NCHITTEST
+            => self.contains(Self::InputMouse),
+            WM_NCMOUSEMOVE..=WM_NCXBUTTONDBLCLK => self.contains(Self::InputMouse),
+            WM_NCPOINTERUPDATE..=WM_POINTERROUTEDRELEASED => self.contains(Self::InputMouse),
             WM_INPUT => self.contains(Self::InputRaw),
 
             WM_MOUSEACTIVATE | WM_ACTIVATEAPP | WM_ACTIVATE | WM_SETFOCUS | WM_KILLFOCUS


### PR DESCRIPTION
We should not dispatch mouse/keyboard events to main game/application if these fields are true, as described in imgui.h comments:
```
bool        WantCaptureMouse;                   // Set when Dear ImGui will use mouse inputs, in this case do not dispatch them to your main game/application (either way, always pass on mouse inputs to imgui). (e.g. unclicked mouse is hovering over an imgui window, widget is active, mouse was clicked over an imgui window, etc.).
bool        WantCaptureKeyboard;                // Set when Dear ImGui will use keyboard inputs, in this case do not dispatch them to your main game/application (either way, always pass keyboard inputs to imgui). (e.g. InputText active, or an imgui window is focused and navigation is enabled, etc.).
```
This prevents some unintentional inputs to main game while operating on imgui windows.