### PR TITLE
fix: resolve DX11 fullscreen errors and washed-out colors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,7 @@ features = [
   "Win32_System_Threading",
   "Win32_UI_Input_KeyboardAndMouse",
   "Win32_UI_WindowsAndMessaging",
+  "Win32_UI_HiDpi",
 ]
 
 [dev-dependencies]

--- a/src/hooks/dx11.rs
+++ b/src/hooks/dx11.rs
@@ -19,7 +19,7 @@ use windows::Win32::Graphics::Direct3D11::{
     D3D11_CREATE_DEVICE_FLAG, D3D11_SDK_VERSION,
 };
 use windows::Win32::Graphics::Dxgi::Common::{
-    DXGI_FORMAT_R8G8B8A8_UNORM, DXGI_MODE_DESC, DXGI_MODE_SCALING_UNSPECIFIED,
+    DXGI_FORMAT, DXGI_FORMAT_R8G8B8A8_UNORM, DXGI_MODE_DESC, DXGI_MODE_SCALING_UNSPECIFIED,
     DXGI_MODE_SCANLINE_ORDER_UNSPECIFIED, DXGI_SAMPLE_DESC,
 };
 use windows::Win32::Graphics::Dxgi::{
@@ -35,8 +35,18 @@ use crate::{perform_eject, Hooks, ImguiRenderLoop, EJECT_REQUESTED, HOOK_EJECTIO
 type DXGISwapChainPresentType =
     unsafe extern "system" fn(this: IDXGISwapChain, sync_interval: u32, flags: u32) -> HRESULT;
 
+type DXGISwapChainResizeBuffersType = unsafe extern "system" fn(
+    this: IDXGISwapChain,
+    buffer_count: u32,
+    width: u32,
+    height: u32,
+    new_format: DXGI_FORMAT,
+    flags: u32,
+) -> HRESULT;
+
 struct Trampolines {
     dxgi_swap_chain_present: DXGISwapChainPresentType,
+    dxgi_swap_chain_resize_buffers: DXGISwapChainResizeBuffersType,
 }
 
 static mut TRAMPOLINES: OnceLock<Trampolines> = OnceLock::new();
@@ -44,7 +54,8 @@ static mut PIPELINE: OnceCell<Mutex<Pipeline<D3D11RenderEngine>>> = OnceCell::ne
 static mut RENDER_LOOP: OnceCell<Box<dyn ImguiRenderLoop + Send + Sync>> = OnceCell::new();
 
 unsafe fn init_pipeline(swap_chain: &IDXGISwapChain) -> Result<Mutex<Pipeline<D3D11RenderEngine>>> {
-    let hwnd = unsafe { swap_chain.GetDesc() }?.OutputWindow;
+    let desc = swap_chain.GetDesc()?;
+    let hwnd = desc.OutputWindow;
 
     let mut ctx = Context::create();
     let engine = D3D11RenderEngine::new(&swap_chain.GetDevice()?, &mut ctx)?;
@@ -71,6 +82,11 @@ fn render(swap_chain: &IDXGISwapChain) -> Result<()> {
             return Err(Error::from_hresult(HRESULT(-1)));
         };
 
+        if let Ok(desc) = swap_chain.GetDesc() {
+            pipeline
+                .update_display_size_from_swap_chain(desc.BufferDesc.Width, desc.BufferDesc.Height);
+        }
+
         pipeline.prepare_render()?;
 
         let target: ID3D11Texture2D = swap_chain.GetBuffer(0)?;
@@ -87,7 +103,7 @@ unsafe extern "system" fn dxgi_swap_chain_present_impl(
 ) -> HRESULT {
     let _hook_ejection_guard = HOOK_EJECTION_BARRIER.acquire_ejection_guard();
 
-    let Trampolines { dxgi_swap_chain_present } =
+    let Trampolines { dxgi_swap_chain_present, .. } =
         TRAMPOLINES.get().expect("DirectX 11 trampolines uninitialized");
 
     if let Err(e) = render(&swap_chain) {
@@ -102,7 +118,35 @@ unsafe extern "system" fn dxgi_swap_chain_present_impl(
     result
 }
 
-fn get_target_addrs() -> DXGISwapChainPresentType {
+unsafe extern "system" fn dxgi_swap_chain_resize_buffers_impl(
+    swap_chain: IDXGISwapChain,
+    buffer_count: u32,
+    width: u32,
+    height: u32,
+    new_format: DXGI_FORMAT,
+    flags: u32,
+) -> HRESULT {
+    let _hook_ejection_guard = HOOK_EJECTION_BARRIER.acquire_ejection_guard();
+
+    let Trampolines { dxgi_swap_chain_resize_buffers, .. } =
+        TRAMPOLINES.get().expect("DirectX 11 trampolines uninitialized");
+
+    trace!("Call IDXGISwapChain::ResizeBuffers trampoline");
+    let result =
+        dxgi_swap_chain_resize_buffers(swap_chain, buffer_count, width, height, new_format, flags);
+
+    if result.is_ok() {
+        if let Some(pipeline) = PIPELINE.get() {
+            if let Some(mut pipeline_guard) = pipeline.try_lock() {
+                pipeline_guard.update_display_size_from_swap_chain(width, height);
+            }
+        }
+    }
+
+    result
+}
+
+fn get_target_addrs() -> (DXGISwapChainPresentType, DXGISwapChainResizeBuffersType) {
     let mut p_device: Option<ID3D11Device> = None;
     let mut p_context: Option<ID3D11DeviceContext> = None;
     let mut p_swap_chain: Option<IDXGISwapChain> = None;
@@ -148,11 +192,17 @@ fn get_target_addrs() -> DXGISwapChainPresentType {
         >(swap_chain.vtable().Present)
     };
 
-    present_ptr
+    let resize_buffers_ptr: DXGISwapChainResizeBuffersType = unsafe {
+        mem::transmute::<*mut c_void, DXGISwapChainResizeBuffersType>(
+            swap_chain.vtable().ResizeBuffers as *mut c_void,
+        )
+    };
+
+    (present_ptr, resize_buffers_ptr)
 }
 
 /// Hooks for DirectX 11.
-pub struct ImguiDx11Hooks([MhHook; 1]);
+pub struct ImguiDx11Hooks([MhHook; 2]);
 
 impl ImguiDx11Hooks {
     /// Construct a set of [`MhHook`]s that will render UI via the
@@ -160,6 +210,7 @@ impl ImguiDx11Hooks {
     ///
     /// The following functions are hooked:
     /// - `IDXGISwapChain::Present`
+    /// - `IDXGISwapChain::ResizeBuffers`
     ///
     /// # Safety
     ///
@@ -168,7 +219,8 @@ impl ImguiDx11Hooks {
     where
         T: ImguiRenderLoop + Send + Sync + 'static,
     {
-        let dxgi_swap_chain_present_addr = get_target_addrs();
+        let (dxgi_swap_chain_present_addr, dxgi_swap_chain_resize_buffers_addr) =
+            get_target_addrs();
 
         trace!("IDXGISwapChain::Present = {:p}", dxgi_swap_chain_present_addr as *const c_void);
         let hook_present = MhHook::new(
@@ -177,14 +229,28 @@ impl ImguiDx11Hooks {
         )
         .expect("couldn't create IDXGISwapChain::Present hook");
 
+        trace!(
+            "IDXGISwapChain::ResizeBuffers = {:p}",
+            dxgi_swap_chain_resize_buffers_addr as *const c_void
+        );
+        let hook_resize_buffers = MhHook::new(
+            dxgi_swap_chain_resize_buffers_addr as *mut _,
+            dxgi_swap_chain_resize_buffers_impl as *mut _,
+        )
+        .expect("couldn't create IDXGISwapChain::ResizeBuffers hook");
+
         RENDER_LOOP.get_or_init(|| Box::new(t));
         TRAMPOLINES.get_or_init(|| Trampolines {
             dxgi_swap_chain_present: mem::transmute::<*mut c_void, DXGISwapChainPresentType>(
                 hook_present.trampoline(),
             ),
+            dxgi_swap_chain_resize_buffers: mem::transmute::<
+                *mut c_void,
+                DXGISwapChainResizeBuffersType,
+            >(hook_resize_buffers.trampoline()),
         });
 
-        Self([hook_present])
+        Self([hook_present, hook_resize_buffers])
     }
 }
 

--- a/src/renderer/backend/dx11.rs
+++ b/src/renderer/backend/dx11.rs
@@ -82,18 +82,26 @@ impl RenderEngine for D3D11RenderEngine {
         unsafe {
             let state_backup = StateBackup::backup(&self.device_context);
 
+            let rtv_desc = {
+                let mut tex_desc = D3D11_TEXTURE2D_DESC::default();
+                render_target.GetDesc(&mut tex_desc);
+                let format = match tex_desc.Format {
+                    DXGI_FORMAT_R8G8B8A8_UNORM_SRGB => DXGI_FORMAT_R8G8B8A8_UNORM,
+                    DXGI_FORMAT_B8G8R8A8_UNORM_SRGB => DXGI_FORMAT_B8G8R8A8_UNORM,
+                    DXGI_FORMAT_B8G8R8X8_UNORM_SRGB => DXGI_FORMAT_B8G8R8X8_UNORM,
+                    other => other,
+                };
+                D3D11_RENDER_TARGET_VIEW_DESC {
+                    Format: format,
+                    ViewDimension: D3D11_RTV_DIMENSION_TEXTURE2D,
+                    Anonymous: D3D11_RENDER_TARGET_VIEW_DESC_0 {
+                        Texture2D: D3D11_TEX2D_RTV { MipSlice: 0 },
+                    },
+                }
+            };
+
             let render_target: ID3D11RenderTargetView = util::try_out_ptr(|v| {
-                self.device.CreateRenderTargetView(
-                    &render_target,
-                    Some(&D3D11_RENDER_TARGET_VIEW_DESC {
-                        Format: DXGI_FORMAT_B8G8R8A8_UNORM,
-                        ViewDimension: D3D11_RTV_DIMENSION_TEXTURE2D,
-                        Anonymous: D3D11_RENDER_TARGET_VIEW_DESC_0 {
-                            Texture2D: D3D11_TEX2D_RTV { MipSlice: 0 },
-                        },
-                    }),
-                    Some(v),
-                )
+                self.device.CreateRenderTargetView(&render_target, Some(&rtv_desc), Some(v))
             })?;
 
             self.device_context.OMSetRenderTargets(Some(&[Some(render_target)]), None);

--- a/src/renderer/backend/dx11.rs
+++ b/src/renderer/backend/dx11.rs
@@ -91,17 +91,44 @@ impl RenderEngine for D3D11RenderEngine {
                     DXGI_FORMAT_B8G8R8X8_UNORM_SRGB => DXGI_FORMAT_B8G8R8X8_UNORM,
                     other => other,
                 };
-                D3D11_RENDER_TARGET_VIEW_DESC {
-                    Format: format,
-                    ViewDimension: D3D11_RTV_DIMENSION_TEXTURE2D,
-                    Anonymous: D3D11_RENDER_TARGET_VIEW_DESC_0 {
-                        Texture2D: D3D11_TEX2D_RTV { MipSlice: 0 },
-                    },
+                if tex_desc.SampleDesc.Count > 1 {
+                    D3D11_RENDER_TARGET_VIEW_DESC {
+                        Format: format,
+                        ViewDimension: D3D11_RTV_DIMENSION_TEXTURE2DMS,
+                        Anonymous: D3D11_RENDER_TARGET_VIEW_DESC_0 {
+                            Texture2DMS: D3D11_TEX2DMS_RTV::default(),
+                        },
+                    }
+                } else if tex_desc.ArraySize > 1 {
+                    D3D11_RENDER_TARGET_VIEW_DESC {
+                        Format: format,
+                        ViewDimension: D3D11_RTV_DIMENSION_TEXTURE2DARRAY,
+                        Anonymous: D3D11_RENDER_TARGET_VIEW_DESC_0 {
+                            Texture2DArray: D3D11_TEX2D_ARRAY_RTV {
+                                MipSlice: 0,
+                                FirstArraySlice: 0,
+                                ArraySize: tex_desc.ArraySize,
+                            },
+                        },
+                    }
+                } else {
+                    D3D11_RENDER_TARGET_VIEW_DESC {
+                        Format: format,
+                        ViewDimension: D3D11_RTV_DIMENSION_TEXTURE2D,
+                        Anonymous: D3D11_RENDER_TARGET_VIEW_DESC_0 {
+                            Texture2D: D3D11_TEX2D_RTV { MipSlice: 0 },
+                        },
+                    }
                 }
             };
 
             let render_target: ID3D11RenderTargetView = util::try_out_ptr(|v| {
                 self.device.CreateRenderTargetView(&render_target, Some(&rtv_desc), Some(v))
+            })
+            .or_else(|_| {
+                util::try_out_ptr(|v| {
+                    self.device.CreateRenderTargetView(&render_target, None, Some(v))
+                })
             })?;
 
             self.device_context.OMSetRenderTargets(Some(&[Some(render_target)]), None);
@@ -149,12 +176,12 @@ impl D3D11RenderEngine {
                 draw_data.display_pos[1] + draw_data.display_size[1],
             ];
 
-            [
-                [2. / (r - l), 0., 0., 0.],
-                [0., 2. / (t - b), 0., 0.],
-                [0., 0., 0.5, 0.],
-                [(r + l) / (l - r), (t + b) / (b - t), 0.5, 1.0],
-            ]
+            [[2. / (r - l), 0., 0., 0.], [0., 2. / (t - b), 0., 0.], [0., 0., 0.5, 0.], [
+                (r + l) / (l - r),
+                (t + b) / (b - t),
+                0.5,
+                1.0,
+            ]]
         });
 
         self.vertex_buffer.upload(&self.device, &self.device_context)?;

--- a/src/renderer/backend/dx11.rs
+++ b/src/renderer/backend/dx11.rs
@@ -131,12 +131,12 @@ impl D3D11RenderEngine {
                 draw_data.display_pos[1] + draw_data.display_size[1],
             ];
 
-            [[2. / (r - l), 0., 0., 0.], [0., 2. / (t - b), 0., 0.], [0., 0., 0.5, 0.], [
-                (r + l) / (l - r),
-                (t + b) / (b - t),
-                0.5,
-                1.0,
-            ]]
+            [
+                [2. / (r - l), 0., 0., 0.],
+                [0., 2. / (t - b), 0., 0.],
+                [0., 0., 0.5, 0.],
+                [(r + l) / (l - r), (t + b) / (b - t), 0.5, 1.0],
+            ]
         });
 
         self.vertex_buffer.upload(&self.device, &self.device_context)?;
@@ -198,8 +198,8 @@ impl D3D11RenderEngine {
         self.device_context.RSSetViewports(Some(&[D3D11_VIEWPORT {
             TopLeftX: 0f32,
             TopLeftY: 0f32,
-            Width: draw_data.display_size[0],
-            Height: draw_data.display_size[1],
+            Width: draw_data.display_size[0] * draw_data.framebuffer_scale[0],
+            Height: draw_data.display_size[1] * draw_data.framebuffer_scale[1],
             MinDepth: 0f32,
             MaxDepth: 1f32,
         }]));
@@ -405,8 +405,8 @@ impl ShaderProgram {
                             SrcBlend: D3D11_BLEND_SRC_ALPHA,
                             DestBlend: D3D11_BLEND_INV_SRC_ALPHA,
                             BlendOp: D3D11_BLEND_OP_ADD,
-                            SrcBlendAlpha: D3D11_BLEND_INV_SRC_ALPHA,
-                            DestBlendAlpha: D3D11_BLEND_ZERO,
+                            SrcBlendAlpha: D3D11_BLEND_ONE,
+                            DestBlendAlpha: D3D11_BLEND_INV_SRC_ALPHA,
                             BlendOpAlpha: D3D11_BLEND_OP_ADD,
                             RenderTargetWriteMask: D3D11_COLOR_WRITE_ENABLE_ALL.0 as _,
                         },

--- a/src/renderer/backend/dx11.rs
+++ b/src/renderer/backend/dx11.rs
@@ -83,7 +83,17 @@ impl RenderEngine for D3D11RenderEngine {
             let state_backup = StateBackup::backup(&self.device_context);
 
             let render_target: ID3D11RenderTargetView = util::try_out_ptr(|v| {
-                self.device.CreateRenderTargetView(&render_target, None, Some(v))
+                self.device.CreateRenderTargetView(
+                    &render_target,
+                    Some(&D3D11_RENDER_TARGET_VIEW_DESC {
+                        Format: DXGI_FORMAT_B8G8R8A8_UNORM,
+                        ViewDimension: D3D11_RTV_DIMENSION_TEXTURE2D,
+                        Anonymous: D3D11_RENDER_TARGET_VIEW_DESC_0 {
+                            Texture2D: D3D11_TEX2D_RTV { MipSlice: 0 },
+                        },
+                    }),
+                    Some(v),
+                )
             })?;
 
             self.device_context.OMSetRenderTargets(Some(&[Some(render_target)]), None);
@@ -406,7 +416,7 @@ impl ShaderProgram {
                             DestBlend: D3D11_BLEND_INV_SRC_ALPHA,
                             BlendOp: D3D11_BLEND_OP_ADD,
                             SrcBlendAlpha: D3D11_BLEND_ONE,
-                            DestBlendAlpha: D3D11_BLEND_INV_SRC_ALPHA,
+                            DestBlendAlpha: D3D11_BLEND_ZERO,
                             BlendOpAlpha: D3D11_BLEND_OP_ADD,
                             RenderTargetWriteMask: D3D11_COLOR_WRITE_ENABLE_ALL.0 as _,
                         },

--- a/src/renderer/backend/dx12.rs
+++ b/src/renderer/backend/dx12.rs
@@ -239,12 +239,12 @@ impl D3D12RenderEngine {
                 draw_data.display_pos[1] + draw_data.display_size[1],
             ];
 
-            [
-                [2. / (r - l), 0., 0., 0.],
-                [0., 2. / (t - b), 0., 0.],
-                [0., 0., 0.5, 0.],
-                [(r + l) / (l - r), (t + b) / (b - t), 0.5, 1.0],
-            ]
+            [[2. / (r - l), 0., 0., 0.], [0., 2. / (t - b), 0., 0.], [0., 0., 0.5, 0.], [
+                (r + l) / (l - r),
+                (t + b) / (b - t),
+                0.5,
+                1.0,
+            ]]
         };
 
         self.setup_render_state(draw_data);

--- a/src/renderer/backend/dx12.rs
+++ b/src/renderer/backend/dx12.rs
@@ -582,7 +582,7 @@ unsafe fn create_shader_program(
                     DestBlend: D3D12_BLEND_INV_SRC_ALPHA,
                     BlendOp: D3D12_BLEND_OP_ADD,
                     SrcBlendAlpha: D3D12_BLEND_ONE,
-                    DestBlendAlpha: D3D12_BLEND_INV_SRC_ALPHA,
+                    DestBlendAlpha: D3D12_BLEND_ZERO,
                     BlendOpAlpha: D3D12_BLEND_OP_ADD,
                     LogicOp: Default::default(),
                     RenderTargetWriteMask: D3D12_COLOR_WRITE_ENABLE_ALL.0 as _,

--- a/src/renderer/backend/dx12.rs
+++ b/src/renderer/backend/dx12.rs
@@ -239,12 +239,12 @@ impl D3D12RenderEngine {
                 draw_data.display_pos[1] + draw_data.display_size[1],
             ];
 
-            [[2. / (r - l), 0., 0., 0.], [0., 2. / (t - b), 0., 0.], [0., 0., 0.5, 0.], [
-                (r + l) / (l - r),
-                (t + b) / (b - t),
-                0.5,
-                1.0,
-            ]]
+            [
+                [2. / (r - l), 0., 0., 0.],
+                [0., 2. / (t - b), 0., 0.],
+                [0., 0., 0.5, 0.],
+                [(r + l) / (l - r), (t + b) / (b - t), 0.5, 1.0],
+            ]
         };
 
         self.setup_render_state(draw_data);
@@ -301,8 +301,8 @@ impl D3D12RenderEngine {
         self.command_list.RSSetViewports(&[D3D12_VIEWPORT {
             TopLeftX: 0f32,
             TopLeftY: 0f32,
-            Width: draw_data.display_size[0],
-            Height: draw_data.display_size[1],
+            Width: draw_data.display_size[0] * draw_data.framebuffer_scale[0],
+            Height: draw_data.display_size[1] * draw_data.framebuffer_scale[1],
             MinDepth: 0f32,
             MaxDepth: 1f32,
         }]);

--- a/src/renderer/pipeline.rs
+++ b/src/renderer/pipeline.rs
@@ -8,9 +8,10 @@ use std::time::{Duration, Instant};
 use imgui::Context;
 use once_cell::sync::{Lazy, OnceCell};
 use parking_lot::Mutex;
-use tracing::error;
-use windows::core::{Error, Result, HRESULT};
+use tracing::{error, warn};
+use windows::core::{Error, Result};
 use windows::Win32::Foundation::{HWND, LPARAM, LRESULT, WPARAM};
+use windows::Win32::UI::HiDpi::GetDpiForWindow;
 use windows::Win32::UI::WindowsAndMessaging::{
     CallWindowProcW, DefWindowProcW, SetWindowLongPtrW, GWLP_WNDPROC,
 };
@@ -147,8 +148,8 @@ impl<T: RenderEngine> Pipeline<T> {
         let [fsw, fsh] = self.ctx.io().display_framebuffer_scale;
 
         if (w * fsw) <= 0.0 || (h * fsh) <= 0.0 {
-            error!("Insufficient display size: {w}x{h}");
-            return Err(Error::from_hresult(HRESULT(-1)));
+            warn!("Insufficient display size: {w}x{h}, framebuffer_scale: {fsw}x{fsh}; skipping frame");
+            return Ok(());
         }
 
         let ui = self.ctx.frame();
@@ -169,7 +170,22 @@ impl<T: RenderEngine> Pipeline<T> {
     }
 
     pub(crate) fn resize(&mut self, width: u32, height: u32) {
-        self.ctx.io_mut().display_size = [width as f32, height as f32];
+        if width > 0 && height > 0 {
+            self.ctx.io_mut().display_size = [width as f32, height as f32];
+        }
+    }
+
+    pub(crate) fn update_display_size_from_swap_chain(&mut self, width: u32, height: u32) {
+        if width > 0 && height > 0 {
+            let io = self.ctx.io_mut();
+            io.display_size = [width as f32, height as f32];
+
+            let dpi = unsafe { GetDpiForWindow(self.hwnd) };
+            if dpi > 0 {
+                let scale = dpi as f32 / 96.0;
+                io.display_framebuffer_scale = [scale, scale];
+            }
+        }
     }
 
     pub(crate) fn cleanup(&mut self) {

--- a/src/renderer/pipeline.rs
+++ b/src/renderer/pipeline.rs
@@ -148,7 +148,10 @@ impl<T: RenderEngine> Pipeline<T> {
         let [fsw, fsh] = self.ctx.io().display_framebuffer_scale;
 
         if (w * fsw) <= 0.0 || (h * fsh) <= 0.0 {
-            warn!("Insufficient display size: {w}x{h}, framebuffer_scale: {fsw}x{fsh}; skipping frame");
+            warn!(
+                "Insufficient display size: {w}x{h}, framebuffer_scale: {fsw}x{fsh}; skipping \
+                 frame"
+            );
             return Ok(());
         }
 


### PR DESCRIPTION
## Summary

Fixes multiple issues that occur when the hooked application switches to fullscreen mode on DirectX 11.

### Problems

1. **`Insufficient display size: 0x0` error spam** - when transitioning to fullscreen, `WM_SIZE` delivers zero dimensions, and `pipeline.resize()` blindly sets `display_size = [0, 0]`, causing an error on every frame.

2. **`Render error: HRESULT(0xFFFFFFFF)`** - the zero display size check returned a hard error instead of skipping the frame gracefully.

3. **ImGui appears washed-out/gray in fullscreen** - caused by:
   - Incorrect alpha blend factors (`SrcBlendAlpha=INV_SRC_ALPHA`, `DestBlendAlpha=ZERO` instead of `ONE`/`ZERO`), leaving the back buffer alpha < 1.0, which DXGI/DWM interprets as semi-transparency in fullscreen compositing.
   - Double gamma correction when the back buffer has an `_SRGB` format and `CreateRenderTargetView` is called with `None` desc (auto-detect inherits the `_SRGB` view, causing the GPU to apply linear to sRGB conversion on top of already-sRGB data).

4. **No `ResizeBuffers` hook for DX11** - unlike DX9 (hooks `Reset`) and DX12 (hooks `ResizeBuffers`), the DX11 hook only intercepted `Present`. When the swap chain resizes buffers during fullscreen transitions, the pipeline has no way to react.

5. **`display_size` never updated from swap chain** - the display size was only set from `GetClientRect` at init and `WM_SIZE` on resize, but never from the actual swap chain back buffer dimensions. In fullscreen, `GetClientRect` and `WM_SIZE` can report incorrect values.

6. **`display_framebuffer_scale` never updated** - on HiDPI displays, the framebuffer scale may change when switching to fullscreen, but it was always left at the default `[1.0, 1.0]`.

7. **`framebuffer_scale` not applied to viewport** - DX11 and DX12 viewports used only `display_size`, ignoring `framebuffer_scale`, causing incorrect rendering on HiDPI displays.

### Changes

- **`pipeline.resize()`**: skip updates when width/height are zero to preserve previous display size
- **`pipeline.render()`**: return `Ok(())` (skip frame with a warning) instead of `Err` when display size is insufficient
- **`Pipeline::update_display_size_from_swap_chain()`**: new method that updates both `display_size` and `display_framebuffer_scale` (from window DPI via `GetDpiForWindow`)
- **DX11 hooks**: add `IDXGISwapChain::ResizeBuffers` hook; update display size from `swap_chain.GetDesc()` before each frame and after `ResizeBuffers`
- **DX11/DX12 blend state**: `SrcBlendAlpha=ONE`, `DestBlendAlpha=ZERO` - ensures back buffer alpha stays 1.0 (matches reference `imgui_impl_dx11.cpp`)
- **DX11/DX12 viewport**: apply `framebuffer_scale` to viewport dimensions
- **DX11 RTV creation**: derive format and `ViewDimension` from back buffer `GetDesc()`, strip `_SRGB` suffix to prevent double gamma; fall back to auto-detect (`None`) if explicit desc fails (handles MSAA, array textures, etc.)
- **Cargo.toml**: add `Win32_UI_HiDpi` feature for `GetDpiForWindow`

## Testing

- All changes compile cleanly with `cargo check` and `cargo check --tests`
- Tested in a DX11 application: fullscreen transition no longer produces error spam, ImGui colors remain correct
