### PR TITLE
Add opt-in DX12 command queue device fallback

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,11 @@ default = ["dx9", "dx11", "dx12", "opengl3", "inject"]
 dx9 = []
 dx11 = []
 dx12 = []
+# Allow the DirectX 12 hook to accept a command queue from the same D3D12
+# device when the private swap-chain memory scan cannot find the queue pointer.
+# This is useful for games/drivers whose DXGI swap-chain implementation does
+# not expose the command queue in a scan-friendly layout.
+dx12-fallback-device-check = ["dx12"]
 opengl3 = ["dep:gl_generator"]
 inject = []
 imgui-freetype = ["imgui/freetype"]

--- a/src/hooks/dx12.rs
+++ b/src/hooks/dx12.rs
@@ -130,9 +130,59 @@ impl InitializationContext {
                      pointers were readable)",
                     readable_ptrs.len()
                 );
+                Self::fallback_check_command_queue(swap_chain, command_queue)
+            },
+        }
+    }
+
+    #[cfg(feature = "dx12-fallback-device-check")]
+    unsafe fn fallback_check_command_queue(
+        swap_chain: &IDXGISwapChain3,
+        command_queue: &ID3D12CommandQueue,
+    ) -> bool {
+        match Self::command_queue_matches_swap_chain_device(swap_chain, command_queue) {
+            Ok(true) => {
+                warn!(
+                    "Accepting command queue because it belongs to the same D3D12 device as the \
+                     swap chain"
+                );
+                true
+            },
+            Ok(false) => {
+                warn!(
+                    "Command queue pointer was not present in the swap chain struct and the \
+                     command queue belongs to a different D3D12 device"
+                );
+                false
+            },
+            Err(e) => {
+                warn!(
+                    "Command queue pointer was not present in the swap chain struct and fallback \
+                     D3D12 device check failed: {e:?}"
+                );
                 false
             },
         }
+    }
+
+    #[cfg(not(feature = "dx12-fallback-device-check"))]
+    unsafe fn fallback_check_command_queue(
+        _swap_chain: &IDXGISwapChain3,
+        _command_queue: &ID3D12CommandQueue,
+    ) -> bool {
+        false
+    }
+
+    #[cfg(feature = "dx12-fallback-device-check")]
+    unsafe fn command_queue_matches_swap_chain_device(
+        swap_chain: &IDXGISwapChain3,
+        command_queue: &ID3D12CommandQueue,
+    ) -> Result<bool> {
+        let swap_chain_device: ID3D12Device = swap_chain.GetDevice()?;
+        let command_queue_device: ID3D12Device =
+            util::try_out_ptr(|device| command_queue.GetDevice(device))?;
+
+        Ok(std::ptr::eq(swap_chain_device.as_raw(), command_queue_device.as_raw()))
     }
 }
 


### PR DESCRIPTION
## Summary

Adds an opt-in DirectX 12 initialization fallback behind the `dx12-fallback-device-check` feature.

When the existing swap-chain memory scan cannot find the observed `ID3D12CommandQueue` pointer, the fallback accepts the command queue if it belongs to the same `ID3D12Device` as the swap chain.

This keeps current default behavior unchanged while providing an escape hatch for games/drivers where the private DXGI swap-chain object layout does not expose the command queue pointer in a scan-friendly way.

## Motivation

Fixes/addresses #256.

In Elden Ring 1.16.1 under Proton, the current DX12 hook repeatedly failed with:

```text
Couldn't find command queue pointer in swap chain struct (512 out of 512 pointers were readable)
Initialization context incomplete
Render error: HRESULT(0xFFFFFFFF)
```

The DLL loaded and the game remained stable, but the ImGui overlay never rendered because initialization never reached `Complete`.

## Validation

Checked both the default path and the new opt-in feature:

```bash
cargo xwin check --target x86_64-pc-windows-msvc --no-default-features --features dx12,imgui-tables-api
cargo xwin check --target x86_64-pc-windows-msvc --no-default-features --features dx12,imgui-tables-api,dx12-fallback-device-check
```

Also tested in-game with a downstream Elden Ring DLL using the feature. The overlay rendered successfully on the Elden Ring main menu. The log no longer showed the repeated command-queue/init spam; only one early startup `Initialization context incomplete` appeared before the render context completed.
