### PR TITLE
fix(dx12): stabilize swap-chain resize handling

### DIFF
--- a/src/hooks/dx12.rs
+++ b/src/hooks/dx12.rs
@@ -9,7 +9,8 @@ use imgui::Context;
 use once_cell::sync::OnceCell;
 use parking_lot::Mutex;
 use tracing::{debug, error, trace, warn};
-use windows::core::{Error, Interface, Result, BOOL, HRESULT};
+use windows::core::{Error, IUnknown, Interface, Result, BOOL, HRESULT};
+use windows::Win32::Foundation::{HWND, LUID};
 use windows::Win32::Graphics::Direct3D::D3D_FEATURE_LEVEL_11_0;
 use windows::Win32::Graphics::Direct3D12::{
     D3D12CreateDevice, ID3D12CommandList, ID3D12CommandQueue, ID3D12Device, ID3D12Resource,
@@ -20,9 +21,11 @@ use windows::Win32::Graphics::Dxgi::Common::{
     DXGI_MODE_SCANLINE_ORDER_UNSPECIFIED, DXGI_RATIONAL, DXGI_SAMPLE_DESC,
 };
 use windows::Win32::Graphics::Dxgi::{
-    CreateDXGIFactory2, IDXGIFactory2, IDXGISwapChain, IDXGISwapChain3, DXGI_CREATE_FACTORY_FLAGS,
-    DXGI_SWAP_CHAIN_DESC, DXGI_SWAP_CHAIN_FLAG_ALLOW_MODE_SWITCH, DXGI_SWAP_EFFECT_FLIP_DISCARD,
-    DXGI_USAGE_RENDER_TARGET_OUTPUT,
+    CreateDXGIFactory2, IDXGIFactory, IDXGIFactory2, IDXGIOutput, IDXGISwapChain, IDXGISwapChain1,
+    IDXGISwapChain2, IDXGISwapChain3, DXGI_CREATE_FACTORY_FLAGS, DXGI_ERROR_DEVICE_REMOVED,
+    DXGI_ERROR_DEVICE_RESET, DXGI_PRESENT_PARAMETERS, DXGI_SWAP_CHAIN_DESC, DXGI_SWAP_CHAIN_DESC1,
+    DXGI_SWAP_CHAIN_FLAG_ALLOW_MODE_SWITCH, DXGI_SWAP_CHAIN_FULLSCREEN_DESC,
+    DXGI_SWAP_EFFECT_FLIP_DISCARD, DXGI_USAGE_RENDER_TARGET_OUTPUT,
 };
 
 use super::DummyHwnd;
@@ -31,15 +34,53 @@ use crate::renderer::{D3D12RenderEngine, Pipeline};
 use crate::{perform_eject, util, Hooks, ImguiRenderLoop, EJECT_REQUESTED, HOOK_EJECTION_BARRIER};
 
 type DXGISwapChainPresentType =
-    unsafe extern "system" fn(this: IDXGISwapChain3, sync_interval: u32, flags: u32) -> HRESULT;
+    unsafe extern "system" fn(this: IDXGISwapChain, sync_interval: u32, flags: u32) -> HRESULT;
+
+type DXGISwapChainPresent1Type = unsafe extern "system" fn(
+    this: IDXGISwapChain1,
+    sync_interval: u32,
+    present_flags: u32,
+    present_parameters: *const DXGI_PRESENT_PARAMETERS,
+) -> HRESULT;
 
 type DXGISwapChainResizeBuffersType = unsafe extern "system" fn(
+    this: IDXGISwapChain,
+    buffer_count: u32,
+    width: u32,
+    height: u32,
+    new_format: DXGI_FORMAT,
+    flags: u32,
+) -> HRESULT;
+
+type DXGISwapChainSetSourceSizeType =
+    unsafe extern "system" fn(this: IDXGISwapChain2, width: u32, height: u32) -> HRESULT;
+
+type DXGISwapChainResizeBuffers1Type = unsafe extern "system" fn(
     this: IDXGISwapChain3,
     buffer_count: u32,
     width: u32,
     height: u32,
     new_format: DXGI_FORMAT,
     flags: u32,
+    creation_node_mask: *const u32,
+    present_queue: *const Option<IUnknown>,
+) -> HRESULT;
+
+type DXGIFactoryCreateSwapChainType = unsafe extern "system" fn(
+    this: IDXGIFactory,
+    device: IUnknown,
+    desc: *const DXGI_SWAP_CHAIN_DESC,
+    swap_chain: *mut Option<IDXGISwapChain>,
+) -> HRESULT;
+
+type DXGIFactoryCreateSwapChainForHwndType = unsafe extern "system" fn(
+    this: IDXGIFactory2,
+    device: IUnknown,
+    hwnd: HWND,
+    desc: *const DXGI_SWAP_CHAIN_DESC1,
+    fullscreen_desc: *const DXGI_SWAP_CHAIN_FULLSCREEN_DESC,
+    restrict_to_output: Option<IDXGIOutput>,
+    swap_chain: *mut Option<IDXGISwapChain1>,
 ) -> HRESULT;
 
 type D3D12CommandQueueExecuteCommandListsType = unsafe extern "system" fn(
@@ -50,7 +91,12 @@ type D3D12CommandQueueExecuteCommandListsType = unsafe extern "system" fn(
 
 struct Trampolines {
     dxgi_swap_chain_present: DXGISwapChainPresentType,
+    dxgi_swap_chain_present1: DXGISwapChainPresent1Type,
     dxgi_swap_chain_resize_buffers: DXGISwapChainResizeBuffersType,
+    dxgi_swap_chain_set_source_size: DXGISwapChainSetSourceSizeType,
+    dxgi_swap_chain_resize_buffers1: DXGISwapChainResizeBuffers1Type,
+    dxgi_factory_create_swap_chain: DXGIFactoryCreateSwapChainType,
+    dxgi_factory_create_swap_chain_for_hwnd: DXGIFactoryCreateSwapChainForHwndType,
     d3d12_command_queue_execute_command_lists: D3D12CommandQueueExecuteCommandListsType,
 }
 
@@ -72,6 +118,20 @@ impl InitializationContext {
             },
             s => s,
         }
+    }
+
+    // Transition to a complete state with a command queue that was provided by
+    // a DXGI factory/present-queue API and therefore does not need private
+    // swap-chain layout probing.
+    fn set_complete(&mut self, swap_chain: &IDXGISwapChain3, command_queue: &ID3D12CommandQueue) {
+        if matches!(self, InitializationContext::Done) {
+            return;
+        }
+
+        trace!(
+            "Found command queue from swap chain creation path {swap_chain:?} at {command_queue:?}"
+        );
+        *self = InitializationContext::Complete(swap_chain.clone(), command_queue.clone());
     }
 
     // Transition to a complete state if the swap chain is set and the command queue
@@ -170,6 +230,322 @@ impl InitState {
 static INIT_STATE: InitState = InitState::new();
 static mut PIPELINE: OnceCell<Mutex<Pipeline<D3D12RenderEngine>>> = OnceCell::new();
 static mut RENDER_LOOP: OnceCell<Box<dyn ImguiRenderLoop + Send + Sync>> = OnceCell::new();
+static ACTIVE_CONTEXT: Mutex<Option<ActiveDx12Context>> = Mutex::new(None);
+
+#[derive(Clone)]
+struct ActiveDx12Context {
+    swap_chain_identity: usize,
+    device_identity: usize,
+    command_queue: ID3D12CommandQueue,
+    command_queue_device_identity: usize,
+    adapter_luid: LUID,
+    rtv_format: DXGI_FORMAT,
+    buffer_count: u32,
+    hwnd: usize,
+}
+
+fn format_luid(luid: LUID) -> String {
+    format!("{:08x}:{:08x}", luid.HighPart, luid.LowPart)
+}
+
+fn identity_ptr(identity: &IUnknown) -> usize {
+    identity.as_raw() as usize
+}
+
+fn command_queue_from_unknown(device: &IUnknown) -> Option<ID3D12CommandQueue> {
+    let Ok(command_queue) = device.cast::<ID3D12CommandQueue>() else {
+        return None;
+    };
+
+    let desc = unsafe { command_queue.GetDesc() };
+    if desc.Type == D3D12_COMMAND_LIST_TYPE_DIRECT {
+        Some(command_queue)
+    } else {
+        None
+    }
+}
+
+enum PresentQueueCapture {
+    Missing,
+    Valid(ID3D12CommandQueue),
+    Invalid,
+}
+
+fn command_queue_from_present_queues(
+    present_queue: *const Option<IUnknown>,
+    creation_node_mask: *const u32,
+    buffer_count: u32,
+) -> PresentQueueCapture {
+    if present_queue.is_null() {
+        return PresentQueueCapture::Missing;
+    }
+
+    if buffer_count == 0 {
+        warn!("ResizeBuffers1 supplied present queues but the queue count is unknown");
+        return PresentQueueCapture::Invalid;
+    }
+
+    let present_queues =
+        unsafe { std::slice::from_raw_parts(present_queue, buffer_count as usize) };
+    let creation_node_masks = if creation_node_mask.is_null() {
+        None
+    } else {
+        Some(unsafe { std::slice::from_raw_parts(creation_node_mask, buffer_count as usize) })
+    };
+
+    let Some(first_unknown) = present_queues.first().and_then(Option::as_ref) else {
+        warn!("ResizeBuffers1 present queue array contains a null first queue");
+        return PresentQueueCapture::Invalid;
+    };
+    let Some(first_queue) = command_queue_from_unknown(first_unknown) else {
+        warn!("ResizeBuffers1 first present queue is not a direct D3D12 command queue");
+        return PresentQueueCapture::Invalid;
+    };
+    let Ok(first_queue_identity) = first_queue.cast::<IUnknown>() else {
+        warn!("ResizeBuffers1 first present queue identity query failed");
+        return PresentQueueCapture::Invalid;
+    };
+    let first_queue_identity = identity_ptr(&first_queue_identity);
+    let first_node_mask = creation_node_masks.and_then(|masks| masks.first().copied());
+
+    for (idx, present_queue) in present_queues.iter().enumerate().skip(1) {
+        let Some(present_queue) = present_queue.as_ref() else {
+            warn!("ResizeBuffers1 present queue array contains a null queue at index {idx}");
+            return PresentQueueCapture::Invalid;
+        };
+        let Some(command_queue) = command_queue_from_unknown(present_queue) else {
+            warn!(
+                "ResizeBuffers1 present queue at index {idx} is not a direct D3D12 command queue"
+            );
+            return PresentQueueCapture::Invalid;
+        };
+        let Ok(command_queue_identity) = command_queue.cast::<IUnknown>() else {
+            warn!("ResizeBuffers1 present queue identity query failed at index {idx}");
+            return PresentQueueCapture::Invalid;
+        };
+        if identity_ptr(&command_queue_identity) != first_queue_identity {
+            warn!(
+                "ResizeBuffers1 supplied multiple distinct present queues; skipping DX12 overlay \
+                 reinitialization"
+            );
+            return PresentQueueCapture::Invalid;
+        }
+
+        if let (Some(masks), Some(first_node_mask)) = (creation_node_masks, first_node_mask) {
+            if masks[idx] != first_node_mask {
+                warn!(
+                    "ResizeBuffers1 supplied different creation node masks; skipping DX12 overlay \
+                     reinitialization"
+                );
+                return PresentQueueCapture::Invalid;
+            }
+        }
+    }
+
+    PresentQueueCapture::Valid(first_queue)
+}
+
+fn create_active_context(
+    swap_chain: &IDXGISwapChain3,
+    command_queue: &ID3D12CommandQueue,
+    swap_chain_desc: &DXGI_SWAP_CHAIN_DESC,
+    rtv_format: DXGI_FORMAT,
+) -> Result<ActiveDx12Context> {
+    let swap_chain_identity: IUnknown = swap_chain.cast()?;
+    let device: ID3D12Device = unsafe { swap_chain.GetDevice()? };
+    let device_identity: IUnknown = device.cast()?;
+    let queue_device: ID3D12Device = util::try_out_ptr(|v| unsafe { command_queue.GetDevice(v) })?;
+    let command_queue_device_identity: IUnknown = queue_device.cast()?;
+    let adapter_luid = unsafe { device.GetAdapterLuid() };
+    let hwnd = swap_chain_desc.OutputWindow.0 as usize;
+
+    Ok(ActiveDx12Context {
+        swap_chain_identity: identity_ptr(&swap_chain_identity),
+        device_identity: identity_ptr(&device_identity),
+        command_queue: command_queue.clone(),
+        command_queue_device_identity: identity_ptr(&command_queue_device_identity),
+        adapter_luid,
+        rtv_format,
+        buffer_count: swap_chain_desc.BufferCount,
+        hwnd,
+    })
+}
+
+unsafe fn reset_pipeline(reason: &str) {
+    warn!("Resetting DX12 pipeline: {reason}");
+
+    if let Some(pipeline) = PIPELINE.take() {
+        let render_loop = pipeline.into_inner().take();
+        if RENDER_LOOP.set(render_loop).is_err() {
+            error!("Render loop cell was not empty while resetting DX12 pipeline");
+        }
+    }
+
+    *ACTIVE_CONTEXT.lock() = None;
+    INIT_STATE.reset();
+}
+
+fn validate_pending_initialization_context(swap_chain: &IDXGISwapChain3) -> Result<bool> {
+    if ACTIVE_CONTEXT.lock().is_some() {
+        return Ok(true);
+    }
+
+    let Some((captured_swap_chain, _)) = ({ INIT_STATE.lock().get() }) else {
+        return Ok(true);
+    };
+
+    let captured_identity: IUnknown = captured_swap_chain.cast()?;
+    let current_identity: IUnknown = swap_chain.cast()?;
+    if identity_ptr(&captured_identity) == identity_ptr(&current_identity) {
+        return Ok(true);
+    }
+
+    warn!("DX12 pending initialization context belongs to a different swap chain; resetting");
+    INIT_STATE.reset();
+    INIT_STATE.lock().insert_swap_chain(swap_chain);
+    Ok(false)
+}
+
+fn validate_active_context(swap_chain: &IDXGISwapChain3) -> Result<bool> {
+    let Some(active) = ACTIVE_CONTEXT.lock().clone() else {
+        return Ok(true);
+    };
+
+    let Ok(current_swap_chain_identity) = swap_chain.cast::<IUnknown>() else {
+        unsafe { reset_pipeline("swap-chain identity query failed") };
+        return Ok(false);
+    };
+    if identity_ptr(&current_swap_chain_identity) != active.swap_chain_identity {
+        unsafe { reset_pipeline("swap-chain replacement") };
+        return Ok(false);
+    }
+
+    let current_device: ID3D12Device = match unsafe { swap_chain.GetDevice() } {
+        Ok(device) => device,
+        Err(e) => {
+            warn!("Could not query DX12 swap-chain device: {e:?}");
+            unsafe { reset_pipeline("swap-chain device query failed") };
+            return Ok(false);
+        },
+    };
+    let Ok(current_device_identity) = current_device.cast::<IUnknown>() else {
+        unsafe { reset_pipeline("swap-chain device identity query failed") };
+        return Ok(false);
+    };
+    let current_device_identity_ptr = identity_ptr(&current_device_identity);
+    if current_device_identity_ptr != active.device_identity {
+        warn!(
+            "DX12 swap-chain device changed; old adapter LUID {}, new adapter LUID {}",
+            format_luid(active.adapter_luid),
+            format_luid(unsafe { current_device.GetAdapterLuid() }),
+        );
+        unsafe { reset_pipeline("swap-chain device replacement") };
+        return Ok(false);
+    }
+
+    let queue_device: ID3D12Device =
+        match util::try_out_ptr(|v| unsafe { active.command_queue.GetDevice(v) }) {
+            Ok(device) => device,
+            Err(e) => {
+                warn!("Could not query DX12 command queue device: {e:?}");
+                unsafe { reset_pipeline("command queue device query failed") };
+                return Ok(false);
+            },
+        };
+    let Ok(queue_device_identity) = queue_device.cast::<IUnknown>() else {
+        unsafe { reset_pipeline("command queue device identity query failed") };
+        return Ok(false);
+    };
+    let queue_device_identity_ptr = identity_ptr(&queue_device_identity);
+    if queue_device_identity_ptr != current_device_identity_ptr
+        || queue_device_identity_ptr != active.command_queue_device_identity
+    {
+        warn!(
+            "DX12 command queue device no longer matches swap-chain device; adapter LUID {}",
+            format_luid(active.adapter_luid),
+        );
+        unsafe { reset_pipeline("command queue device mismatch") };
+        return Ok(false);
+    }
+
+    let device_removed_reason = unsafe { current_device.GetDeviceRemovedReason() };
+    if device_removed_reason.is_err() {
+        warn!("DX12 device removed/reset: {device_removed_reason:?}");
+        unsafe { reset_pipeline("device removed") };
+        return Ok(false);
+    }
+
+    let swap_chain_desc = unsafe { swap_chain.GetDesc()? };
+    let Some(current_rtv_format) =
+        D3D12RenderEngine::rtv_format_for_swap_chain(swap_chain_desc.BufferDesc.Format)
+    else {
+        warn!(
+            "DX12 swap-chain format {:?} is not supported by hudhook; skipping overlay",
+            swap_chain_desc.BufferDesc.Format,
+        );
+        unsafe { reset_pipeline("unsupported swap-chain format") };
+        return Ok(false);
+    };
+    if current_rtv_format != active.rtv_format || swap_chain_desc.BufferCount != active.buffer_count
+    {
+        let command_queue = active.command_queue.clone();
+        unsafe {
+            reset_pipeline("swap-chain format or buffer count changed");
+            complete_initialization_from_queue(swap_chain, &command_queue);
+        }
+        return Ok(false);
+    }
+
+    Ok(true)
+}
+
+unsafe fn handle_present_result(where_: &str, result: HRESULT) {
+    if result == DXGI_ERROR_DEVICE_REMOVED || result == DXGI_ERROR_DEVICE_RESET {
+        reset_pipeline(where_);
+    }
+}
+
+unsafe fn complete_initialization_from_queue(
+    swap_chain: &IDXGISwapChain3,
+    command_queue: &ID3D12CommandQueue,
+) {
+    INIT_STATE.lock().set_complete(swap_chain, command_queue);
+}
+
+unsafe fn handle_swap_chain_created(
+    hwnd: HWND,
+    device: &IUnknown,
+    swap_chain: Option<IDXGISwapChain3>,
+    result: HRESULT,
+) {
+    if result.is_err() {
+        return;
+    }
+
+    let Some(swap_chain) = swap_chain else {
+        return;
+    };
+
+    let Some(command_queue) = command_queue_from_unknown(device) else {
+        return;
+    };
+
+    if let Some(active) = ACTIVE_CONTEXT.lock().clone() {
+        let hwnd = hwnd.0 as usize;
+        if hwnd != 0 && active.hwnd != 0 && hwnd != active.hwnd {
+            return;
+        }
+
+        if let Ok(current_identity) = swap_chain.cast::<IUnknown>() {
+            if identity_ptr(&current_identity) != active.swap_chain_identity {
+                reset_pipeline("swap-chain creation replacement");
+            }
+        }
+    }
+
+    trace!("Captured DX12 command queue from swap-chain creation for HWND {hwnd:?}");
+    complete_initialization_from_queue(&swap_chain, &command_queue);
+}
 
 unsafe fn init_pipeline() -> Result<Mutex<Pipeline<D3D12RenderEngine>>> {
     let Some((swap_chain, command_queue)) = ({ INIT_STATE.lock().get() }) else {
@@ -177,10 +553,22 @@ unsafe fn init_pipeline() -> Result<Mutex<Pipeline<D3D12RenderEngine>>> {
         return Err(Error::from_hresult(HRESULT(-1)));
     };
 
-    let hwnd = unsafe { swap_chain.GetDesc() }?.OutputWindow;
+    let swap_chain_desc = unsafe { swap_chain.GetDesc() }?;
+    let Some(rtv_format) =
+        D3D12RenderEngine::rtv_format_for_swap_chain(swap_chain_desc.BufferDesc.Format)
+    else {
+        warn!(
+            "DX12 swap-chain format {:?} is not supported by hudhook; skipping overlay",
+            swap_chain_desc.BufferDesc.Format,
+        );
+        return Err(Error::from_hresult(HRESULT(-1)));
+    };
+    let hwnd = swap_chain_desc.OutputWindow;
+    let active_context =
+        create_active_context(&swap_chain, &command_queue, &swap_chain_desc, rtv_format)?;
 
     let mut ctx = Context::create();
-    let engine = D3D12RenderEngine::new(&command_queue, &mut ctx)?;
+    let engine = D3D12RenderEngine::new(&command_queue, &mut ctx, rtv_format)?;
 
     let Some(render_loop) = RENDER_LOOP.take() else {
         error!("Render loop not yet initialized");
@@ -192,13 +580,52 @@ unsafe fn init_pipeline() -> Result<Mutex<Pipeline<D3D12RenderEngine>>> {
         e
     })?;
 
+    *ACTIVE_CONTEXT.lock() = Some(active_context);
     INIT_STATE.mark_done();
 
     Ok(Mutex::new(pipeline))
 }
 
+fn update_pipeline_display_size_from_swap_chain(
+    pipeline: &mut Pipeline<D3D12RenderEngine>,
+    swap_chain: &IDXGISwapChain3,
+) -> Result<()> {
+    let desc = unsafe { swap_chain.GetDesc() }?;
+    pipeline.update_display_size_from_swap_chain(desc.BufferDesc.Width, desc.BufferDesc.Height);
+    Ok(())
+}
+
+unsafe fn wait_for_pipeline_idle() -> Result<()> {
+    if let Some(pipeline) = PIPELINE.get() {
+        pipeline.lock().wait_idle()?;
+    }
+
+    Ok(())
+}
+
 fn render(swap_chain: &IDXGISwapChain3) -> Result<()> {
     unsafe {
+        if !validate_pending_initialization_context(swap_chain)? {
+            return Ok(());
+        }
+        if !validate_active_context(swap_chain)? {
+            return Ok(());
+        }
+
+        let swap_chain_desc = swap_chain.GetDesc()?;
+        if D3D12RenderEngine::rtv_format_for_swap_chain(swap_chain_desc.BufferDesc.Format).is_none()
+        {
+            warn!(
+                "DX12 swap-chain format {:?} is not supported by hudhook; skipping overlay",
+                swap_chain_desc.BufferDesc.Format,
+            );
+            return Ok(());
+        }
+
+        if PIPELINE.get().is_none() && INIT_STATE.lock().get().is_none() {
+            return Ok(());
+        }
+
         let pipeline = PIPELINE.get_or_try_init(|| init_pipeline())?;
 
         let Some(mut pipeline) = pipeline.try_lock() else {
@@ -206,7 +633,17 @@ fn render(swap_chain: &IDXGISwapChain3) -> Result<()> {
             return Err(Error::from_hresult(HRESULT(-1)));
         };
 
+        if let Err(e) = update_pipeline_display_size_from_swap_chain(&mut pipeline, swap_chain) {
+            warn!("Could not update DX12 display size from swap chain: {e:?}");
+        }
+
         pipeline.prepare_render()?;
+
+        if let Err(e) = update_pipeline_display_size_from_swap_chain(&mut pipeline, swap_chain) {
+            warn!(
+                "Could not update DX12 display size from swap chain after window messages: {e:?}"
+            );
+        }
 
         let target: ID3D12Resource =
             swap_chain.GetBuffer(swap_chain.GetCurrentBackBufferIndex())?;
@@ -218,25 +655,63 @@ fn render(swap_chain: &IDXGISwapChain3) -> Result<()> {
 }
 
 unsafe extern "system" fn dxgi_swap_chain_present_impl(
-    swap_chain: IDXGISwapChain3,
+    swap_chain: IDXGISwapChain,
     sync_interval: u32,
     flags: u32,
 ) -> HRESULT {
     let _hook_ejection_guard = HOOK_EJECTION_BARRIER.acquire_ejection_guard();
-    {
-        INIT_STATE.lock().insert_swap_chain(&swap_chain);
+    let swap_chain3 = swap_chain.cast::<IDXGISwapChain3>().ok();
+    if let Some(swap_chain3) = &swap_chain3 {
+        INIT_STATE.lock().insert_swap_chain(swap_chain3);
     }
 
     let Trampolines { dxgi_swap_chain_present, .. } =
         TRAMPOLINES.get().expect("DirectX 12 trampolines uninitialized");
 
-    if let Err(e) = render(&swap_chain) {
-        util::print_dxgi_debug_messages();
-        error!("Render error: {e:?}");
+    if let Some(swap_chain3) = &swap_chain3 {
+        if let Err(e) = render(swap_chain3) {
+            util::print_dxgi_debug_messages();
+            error!("Render error: {e:?}");
+        }
     }
 
     trace!("Call IDXGISwapChain::Present trampoline");
     let result = dxgi_swap_chain_present(swap_chain, sync_interval, flags);
+    handle_present_result("IDXGISwapChain::Present", result);
+
+    if EJECT_REQUESTED.load(Ordering::SeqCst) {
+        perform_eject();
+    }
+
+    result
+}
+
+unsafe extern "system" fn dxgi_swap_chain_present1_impl(
+    swap_chain: IDXGISwapChain1,
+    sync_interval: u32,
+    present_flags: u32,
+    present_parameters: *const DXGI_PRESENT_PARAMETERS,
+) -> HRESULT {
+    let _hook_ejection_guard = HOOK_EJECTION_BARRIER.acquire_ejection_guard();
+    let swap_chain3 = swap_chain.cast::<IDXGISwapChain3>().ok();
+    if let Some(swap_chain3) = &swap_chain3 {
+        INIT_STATE.lock().insert_swap_chain(swap_chain3);
+    }
+
+    let Trampolines { dxgi_swap_chain_present1, .. } =
+        TRAMPOLINES.get().expect("DirectX 12 trampolines uninitialized");
+
+    if let Some(swap_chain3) = &swap_chain3 {
+        if let Err(e) = render(swap_chain3) {
+            util::print_dxgi_debug_messages();
+            error!("Render error: {e:?}");
+        }
+    }
+
+    trace!("Call IDXGISwapChain::Present1 trampoline");
+    let result =
+        dxgi_swap_chain_present1(swap_chain, sync_interval, present_flags, present_parameters);
+    handle_present_result("IDXGISwapChain1::Present1", result);
 
     if EJECT_REQUESTED.load(Ordering::SeqCst) {
         perform_eject();
@@ -246,7 +721,7 @@ unsafe extern "system" fn dxgi_swap_chain_present_impl(
 }
 
 unsafe extern "system" fn dxgi_swap_chain_resize_buffers_impl(
-    p_this: IDXGISwapChain3,
+    p_this: IDXGISwapChain,
     buffer_count: u32,
     width: u32,
     height: u32,
@@ -257,8 +732,149 @@ unsafe extern "system" fn dxgi_swap_chain_resize_buffers_impl(
     let Trampolines { dxgi_swap_chain_resize_buffers, .. } =
         TRAMPOLINES.get().expect("DirectX 12 trampolines uninitialized");
 
+    if let Err(e) = wait_for_pipeline_idle() {
+        util::print_dxgi_debug_messages();
+        error!("Could not wait for DX12 pipeline to become idle before ResizeBuffers: {e:?}");
+    }
+
+    let swap_chain3 = p_this.cast::<IDXGISwapChain3>().ok();
+
     trace!("Call IDXGISwapChain::ResizeBuffers trampoline");
-    dxgi_swap_chain_resize_buffers(p_this, buffer_count, width, height, new_format, flags)
+    let result =
+        dxgi_swap_chain_resize_buffers(p_this, buffer_count, width, height, new_format, flags);
+
+    if result.is_ok() {
+        if let (Some(swap_chain3), Some(pipeline)) = (swap_chain3.as_ref(), PIPELINE.get()) {
+            if let Some(mut pipeline) = pipeline.try_lock() {
+                if let Err(e) =
+                    update_pipeline_display_size_from_swap_chain(&mut pipeline, swap_chain3)
+                {
+                    warn!("Could not update DX12 display size after ResizeBuffers: {e:?}");
+                }
+            } else {
+                warn!("Could not lock DX12 pipeline to update display size after ResizeBuffers");
+            }
+        }
+    }
+
+    result
+}
+
+unsafe extern "system" fn dxgi_swap_chain_set_source_size_impl(
+    swap_chain: IDXGISwapChain2,
+    width: u32,
+    height: u32,
+) -> HRESULT {
+    let _hook_ejection_guard = HOOK_EJECTION_BARRIER.acquire_ejection_guard();
+    let Trampolines { dxgi_swap_chain_set_source_size, .. } =
+        TRAMPOLINES.get().expect("DirectX 12 trampolines uninitialized");
+
+    if let Err(e) = wait_for_pipeline_idle() {
+        util::print_dxgi_debug_messages();
+        error!("Could not wait for DX12 pipeline to become idle before SetSourceSize: {e:?}");
+    }
+
+    trace!("Call IDXGISwapChain2::SetSourceSize trampoline");
+    let result = dxgi_swap_chain_set_source_size(swap_chain.clone(), width, height);
+
+    if result.is_ok() {
+        if let Ok(swap_chain3) = swap_chain.cast::<IDXGISwapChain3>() {
+            if let Some(pipeline) = PIPELINE.get() {
+                if let Some(mut pipeline) = pipeline.try_lock() {
+                    if let Err(e) =
+                        update_pipeline_display_size_from_swap_chain(&mut pipeline, &swap_chain3)
+                    {
+                        warn!("Could not update DX12 display size after SetSourceSize: {e:?}");
+                    }
+                } else {
+                    warn!(
+                        "Could not lock DX12 pipeline to update display size after SetSourceSize"
+                    );
+                }
+            }
+        }
+    }
+
+    result
+}
+
+unsafe extern "system" fn dxgi_swap_chain_resize_buffers1_impl(
+    p_this: IDXGISwapChain3,
+    buffer_count: u32,
+    width: u32,
+    height: u32,
+    new_format: DXGI_FORMAT,
+    flags: u32,
+    creation_node_mask: *const u32,
+    present_queue: *const Option<IUnknown>,
+) -> HRESULT {
+    let _hook_ejection_guard = HOOK_EJECTION_BARRIER.acquire_ejection_guard();
+    let Trampolines { dxgi_swap_chain_resize_buffers1, .. } =
+        TRAMPOLINES.get().expect("DirectX 12 trampolines uninitialized");
+
+    if let Err(e) = wait_for_pipeline_idle() {
+        util::print_dxgi_debug_messages();
+        error!("Could not wait for DX12 pipeline to become idle before ResizeBuffers1: {e:?}");
+    }
+
+    let swap_chain = p_this.clone();
+    let present_queue_count = if present_queue.is_null() {
+        0
+    } else if buffer_count != 0 {
+        buffer_count
+    } else {
+        match swap_chain.GetDesc() {
+            Ok(desc) => desc.BufferCount,
+            Err(e) => {
+                warn!("Could not query DX12 swap-chain buffer count before ResizeBuffers1: {e:?}");
+                0
+            },
+        }
+    };
+    let command_queue =
+        command_queue_from_present_queues(present_queue, creation_node_mask, present_queue_count);
+
+    trace!("Call IDXGISwapChain3::ResizeBuffers1 trampoline");
+    let result = dxgi_swap_chain_resize_buffers1(
+        p_this,
+        buffer_count,
+        width,
+        height,
+        new_format,
+        flags,
+        creation_node_mask,
+        present_queue,
+    );
+
+    if result.is_ok() {
+        match command_queue {
+            PresentQueueCapture::Valid(command_queue) => {
+                reset_pipeline("ResizeBuffers1 present queue update");
+                complete_initialization_from_queue(&swap_chain, &command_queue);
+            },
+            PresentQueueCapture::Invalid => {
+                reset_pipeline("ResizeBuffers1 unsupported present queue configuration");
+            },
+            PresentQueueCapture::Missing => {
+                if let Some(pipeline) = PIPELINE.get() {
+                    if let Some(mut pipeline) = pipeline.try_lock() {
+                        if let Err(e) =
+                            update_pipeline_display_size_from_swap_chain(&mut pipeline, &swap_chain)
+                        {
+                            warn!("Could not update DX12 display size after ResizeBuffers1: {e:?}");
+                        }
+                    } else {
+                        warn!(
+                            "Could not lock DX12 pipeline to update display size after \
+                             ResizeBuffers1"
+                        );
+                    }
+                }
+            },
+        }
+    }
+
+    result
 }
 
 unsafe extern "system" fn d3d12_command_queue_execute_command_lists_impl(
@@ -285,9 +901,72 @@ unsafe extern "system" fn d3d12_command_queue_execute_command_lists_impl(
     d3d12_command_queue_execute_command_lists(command_queue, num_command_lists, command_lists);
 }
 
+unsafe extern "system" fn dxgi_factory_create_swap_chain_impl(
+    factory: IDXGIFactory,
+    device: IUnknown,
+    desc: *const DXGI_SWAP_CHAIN_DESC,
+    swap_chain: *mut Option<IDXGISwapChain>,
+) -> HRESULT {
+    let _hook_ejection_guard = HOOK_EJECTION_BARRIER.acquire_ejection_guard();
+    let Trampolines { dxgi_factory_create_swap_chain, .. } =
+        TRAMPOLINES.get().expect("DirectX 12 trampolines uninitialized");
+
+    trace!("Call IDXGIFactory::CreateSwapChain trampoline");
+    let result = dxgi_factory_create_swap_chain(factory, device.clone(), desc, swap_chain);
+
+    let hwnd = if desc.is_null() { HWND::default() } else { (*desc).OutputWindow };
+    let swap_chain3 = if swap_chain.is_null() {
+        None
+    } else {
+        (*swap_chain).as_ref().and_then(|swap_chain| swap_chain.cast().ok())
+    };
+    handle_swap_chain_created(hwnd, &device, swap_chain3, result);
+
+    result
+}
+
+unsafe extern "system" fn dxgi_factory_create_swap_chain_for_hwnd_impl(
+    factory: IDXGIFactory2,
+    device: IUnknown,
+    hwnd: HWND,
+    desc: *const DXGI_SWAP_CHAIN_DESC1,
+    fullscreen_desc: *const DXGI_SWAP_CHAIN_FULLSCREEN_DESC,
+    restrict_to_output: Option<IDXGIOutput>,
+    swap_chain: *mut Option<IDXGISwapChain1>,
+) -> HRESULT {
+    let _hook_ejection_guard = HOOK_EJECTION_BARRIER.acquire_ejection_guard();
+    let Trampolines { dxgi_factory_create_swap_chain_for_hwnd, .. } =
+        TRAMPOLINES.get().expect("DirectX 12 trampolines uninitialized");
+
+    trace!("Call IDXGIFactory2::CreateSwapChainForHwnd trampoline");
+    let result = dxgi_factory_create_swap_chain_for_hwnd(
+        factory,
+        device.clone(),
+        hwnd,
+        desc,
+        fullscreen_desc,
+        restrict_to_output,
+        swap_chain,
+    );
+
+    let swap_chain3 = if swap_chain.is_null() {
+        None
+    } else {
+        (*swap_chain).as_ref().and_then(|swap_chain| swap_chain.cast().ok())
+    };
+    handle_swap_chain_created(hwnd, &device, swap_chain3, result);
+
+    result
+}
+
 fn get_target_addrs() -> (
+    DXGIFactoryCreateSwapChainType,
+    DXGIFactoryCreateSwapChainForHwndType,
     DXGISwapChainPresentType,
+    DXGISwapChainPresent1Type,
     DXGISwapChainResizeBuffersType,
+    DXGISwapChainSetSourceSizeType,
+    DXGISwapChainResizeBuffers1Type,
     D3D12CommandQueueExecuteCommandListsType,
 ) {
     let dummy_hwnd = DummyHwnd::new();
@@ -342,26 +1021,53 @@ fn get_target_addrs() -> (
         },
     };
 
+    let swap_chain2: IDXGISwapChain2 = swap_chain.cast().unwrap();
+    let swap_chain3: IDXGISwapChain3 = swap_chain.cast().unwrap();
+
+    let create_swap_chain_ptr: DXGIFactoryCreateSwapChainType =
+        unsafe { mem::transmute(factory.vtable().base__.base__.CreateSwapChain) };
+    let create_swap_chain_for_hwnd_ptr: DXGIFactoryCreateSwapChainForHwndType =
+        unsafe { mem::transmute(factory.vtable().CreateSwapChainForHwnd) };
     let present_ptr: DXGISwapChainPresentType =
         unsafe { mem::transmute(swap_chain.vtable().Present) };
+    let present1_ptr: DXGISwapChainPresent1Type =
+        unsafe { mem::transmute(swap_chain3.vtable().base__.base__.Present1) };
     let resize_buffers_ptr: DXGISwapChainResizeBuffersType =
         unsafe { mem::transmute(swap_chain.vtable().ResizeBuffers) };
+    let set_source_size_ptr: DXGISwapChainSetSourceSizeType =
+        unsafe { mem::transmute(swap_chain2.vtable().SetSourceSize) };
+    let resize_buffers1_ptr: DXGISwapChainResizeBuffers1Type =
+        unsafe { mem::transmute(swap_chain3.vtable().ResizeBuffers1) };
     let cqecl_ptr: D3D12CommandQueueExecuteCommandListsType =
         unsafe { mem::transmute(command_queue.vtable().ExecuteCommandLists) };
 
-    (present_ptr, resize_buffers_ptr, cqecl_ptr)
+    (
+        create_swap_chain_ptr,
+        create_swap_chain_for_hwnd_ptr,
+        present_ptr,
+        present1_ptr,
+        resize_buffers_ptr,
+        set_source_size_ptr,
+        resize_buffers1_ptr,
+        cqecl_ptr,
+    )
 }
 
 /// Hooks for DirectX 12.
-pub struct ImguiDx12Hooks([MhHook; 3]);
+pub struct ImguiDx12Hooks([MhHook; 8]);
 
 impl ImguiDx12Hooks {
     /// Construct a set of [`MhHook`]s that will render UI via the
     /// provided [`ImguiRenderLoop`].
     ///
     /// The following functions are hooked:
+    /// - `IDXGIFactory::CreateSwapChain`
+    /// - `IDXGIFactory2::CreateSwapChainForHwnd`
     /// - `IDXGISwapChain3::Present`
+    /// - `IDXGISwapChain3::Present1`
     /// - `IDXGISwapChain3::ResizeBuffers`
+    /// - `IDXGISwapChain2::SetSourceSize`
+    /// - `IDXGISwapChain3::ResizeBuffers1`
     /// - `ID3D12CommandQueue::ExecuteCommandLists`
     ///
     /// # Safety
@@ -372,22 +1078,61 @@ impl ImguiDx12Hooks {
         T: ImguiRenderLoop + Send + Sync + 'static,
     {
         let (
+            dxgi_factory_create_swap_chain_addr,
+            dxgi_factory_create_swap_chain_for_hwnd_addr,
             dxgi_swap_chain_present_addr,
+            dxgi_swap_chain_present1_addr,
             dxgi_swap_chain_resize_buffers_addr,
+            dxgi_swap_chain_set_source_size_addr,
+            dxgi_swap_chain_resize_buffers1_addr,
             d3d12_command_queue_execute_command_lists_addr,
         ) = get_target_addrs();
 
+        trace!(
+            "IDXGIFactory::CreateSwapChain = {:p}",
+            dxgi_factory_create_swap_chain_addr as *const c_void
+        );
+        let hook_create_swap_chain = MhHook::new(
+            dxgi_factory_create_swap_chain_addr as *mut _,
+            dxgi_factory_create_swap_chain_impl as *mut _,
+        )
+        .expect("couldn't create IDXGIFactory::CreateSwapChain hook");
+        trace!(
+            "IDXGIFactory2::CreateSwapChainForHwnd = {:p}",
+            dxgi_factory_create_swap_chain_for_hwnd_addr as *const c_void
+        );
+        let hook_create_swap_chain_for_hwnd = MhHook::new(
+            dxgi_factory_create_swap_chain_for_hwnd_addr as *mut _,
+            dxgi_factory_create_swap_chain_for_hwnd_impl as *mut _,
+        )
+        .expect("couldn't create IDXGIFactory2::CreateSwapChainForHwnd hook");
         trace!("IDXGISwapChain::Present = {:p}", dxgi_swap_chain_present_addr as *const c_void);
         let hook_present = MhHook::new(
             dxgi_swap_chain_present_addr as *mut _,
             dxgi_swap_chain_present_impl as *mut _,
         )
         .expect("couldn't create IDXGISwapChain::Present hook");
+        trace!("IDXGISwapChain1::Present1 = {:p}", dxgi_swap_chain_present1_addr as *const c_void);
+        let hook_present1 = MhHook::new(
+            dxgi_swap_chain_present1_addr as *mut _,
+            dxgi_swap_chain_present1_impl as *mut _,
+        )
+        .expect("couldn't create IDXGISwapChain1::Present1 hook");
         let hook_resize_buffers = MhHook::new(
             dxgi_swap_chain_resize_buffers_addr as *mut _,
             dxgi_swap_chain_resize_buffers_impl as *mut _,
         )
         .expect("couldn't create IDXGISwapChain::ResizeBuffers hook");
+        let hook_set_source_size = MhHook::new(
+            dxgi_swap_chain_set_source_size_addr as *mut _,
+            dxgi_swap_chain_set_source_size_impl as *mut _,
+        )
+        .expect("couldn't create IDXGISwapChain2::SetSourceSize hook");
+        let hook_resize_buffers1 = MhHook::new(
+            dxgi_swap_chain_resize_buffers1_addr as *mut _,
+            dxgi_swap_chain_resize_buffers1_impl as *mut _,
+        )
+        .expect("couldn't create IDXGISwapChain3::ResizeBuffers1 hook");
         let hook_cqecl = MhHook::new(
             d3d12_command_queue_execute_command_lists_addr as *mut _,
             d3d12_command_queue_execute_command_lists_impl as *mut _,
@@ -397,20 +1142,50 @@ impl ImguiDx12Hooks {
         RENDER_LOOP.get_or_init(|| Box::new(t));
 
         TRAMPOLINES.get_or_init(|| Trampolines {
+            dxgi_factory_create_swap_chain: mem::transmute::<
+                *mut c_void,
+                DXGIFactoryCreateSwapChainType,
+            >(hook_create_swap_chain.trampoline()),
+            dxgi_factory_create_swap_chain_for_hwnd: mem::transmute::<
+                *mut c_void,
+                DXGIFactoryCreateSwapChainForHwndType,
+            >(
+                hook_create_swap_chain_for_hwnd.trampoline()
+            ),
             dxgi_swap_chain_present: mem::transmute::<*mut c_void, DXGISwapChainPresentType>(
                 hook_present.trampoline(),
+            ),
+            dxgi_swap_chain_present1: mem::transmute::<*mut c_void, DXGISwapChainPresent1Type>(
+                hook_present1.trampoline(),
             ),
             dxgi_swap_chain_resize_buffers: mem::transmute::<
                 *mut c_void,
                 DXGISwapChainResizeBuffersType,
             >(hook_resize_buffers.trampoline()),
+            dxgi_swap_chain_set_source_size: mem::transmute::<
+                *mut c_void,
+                DXGISwapChainSetSourceSizeType,
+            >(hook_set_source_size.trampoline()),
+            dxgi_swap_chain_resize_buffers1: mem::transmute::<
+                *mut c_void,
+                DXGISwapChainResizeBuffers1Type,
+            >(hook_resize_buffers1.trampoline()),
             d3d12_command_queue_execute_command_lists: mem::transmute::<
                 *mut c_void,
                 D3D12CommandQueueExecuteCommandListsType,
             >(hook_cqecl.trampoline()),
         });
 
-        Self([hook_present, hook_resize_buffers, hook_cqecl])
+        Self([
+            hook_create_swap_chain,
+            hook_create_swap_chain_for_hwnd,
+            hook_present,
+            hook_present1,
+            hook_resize_buffers,
+            hook_set_source_size,
+            hook_resize_buffers1,
+            hook_cqecl,
+        ])
     }
 }
 
@@ -432,6 +1207,7 @@ impl Hooks for ImguiDx12Hooks {
         PIPELINE.take().map(|p| p.into_inner().take());
         RENDER_LOOP.take();
 
+        *ACTIVE_CONTEXT.lock() = None;
         INIT_STATE.reset();
     }
 }

--- a/src/hooks/dx12.rs
+++ b/src/hooks/dx12.rs
@@ -1,6 +1,7 @@
 //! Hooks for DirectX 12.
 
 use std::ffi::c_void;
+use std::fmt::{self, Display};
 use std::mem;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::OnceLock;
@@ -244,8 +245,12 @@ struct ActiveDx12Context {
     hwnd: usize,
 }
 
-fn format_luid(luid: LUID) -> String {
-    format!("{:08x}:{:08x}", luid.HighPart, luid.LowPart)
+struct FmtLuid(LUID);
+
+impl Display for FmtLuid {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "{:08x}:{:08x}", self.0.HighPart, self.0.LowPart)
+    }
 }
 
 fn identity_ptr(identity: &IUnknown) -> usize {
@@ -436,8 +441,8 @@ fn validate_active_context(swap_chain: &IDXGISwapChain3) -> Result<bool> {
     if current_device_identity_ptr != active.device_identity {
         warn!(
             "DX12 swap-chain device changed; old adapter LUID {}, new adapter LUID {}",
-            format_luid(active.adapter_luid),
-            format_luid(unsafe { current_device.GetAdapterLuid() }),
+            FmtLuid(active.adapter_luid),
+            FmtLuid(unsafe { current_device.GetAdapterLuid() }),
         );
         unsafe { reset_pipeline("swap-chain device replacement") };
         return Ok(false);
@@ -462,7 +467,7 @@ fn validate_active_context(swap_chain: &IDXGISwapChain3) -> Result<bool> {
     {
         warn!(
             "DX12 command queue device no longer matches swap-chain device; adapter LUID {}",
-            format_luid(active.adapter_luid),
+            FmtLuid(active.adapter_luid),
         );
         unsafe { reset_pipeline("command queue device mismatch") };
         return Ok(false);
@@ -603,6 +608,30 @@ unsafe fn wait_for_pipeline_idle() -> Result<()> {
     Ok(())
 }
 
+unsafe fn wait_for_pipeline_idle_before(operation: &str) {
+    if let Err(error) = wait_for_pipeline_idle() {
+        util::print_dxgi_debug_messages();
+        error!("Could not wait for DX12 pipeline to become idle before {operation}: {error:?}");
+    }
+}
+
+unsafe fn update_display_size_after_swap_chain_change(
+    swap_chain: &IDXGISwapChain3,
+    operation: &str,
+) {
+    let Some(pipeline) = PIPELINE.get() else {
+        return;
+    };
+    let Some(mut pipeline) = pipeline.try_lock() else {
+        warn!("Could not lock DX12 pipeline to update display size after {operation}");
+        return;
+    };
+
+    if let Err(error) = update_pipeline_display_size_from_swap_chain(&mut pipeline, swap_chain) {
+        warn!("Could not update DX12 display size after {operation}: {error:?}");
+    }
+}
+
 fn render(swap_chain: &IDXGISwapChain3) -> Result<()> {
     unsafe {
         if !validate_pending_initialization_context(swap_chain)? {
@@ -732,30 +761,21 @@ unsafe extern "system" fn dxgi_swap_chain_resize_buffers_impl(
     let Trampolines { dxgi_swap_chain_resize_buffers, .. } =
         TRAMPOLINES.get().expect("DirectX 12 trampolines uninitialized");
 
-    if let Err(e) = wait_for_pipeline_idle() {
-        util::print_dxgi_debug_messages();
-        error!("Could not wait for DX12 pipeline to become idle before ResizeBuffers: {e:?}");
-    }
+    wait_for_pipeline_idle_before("ResizeBuffers");
 
     let swap_chain3 = p_this.cast::<IDXGISwapChain3>().ok();
 
     trace!("Call IDXGISwapChain::ResizeBuffers trampoline");
     let result =
         dxgi_swap_chain_resize_buffers(p_this, buffer_count, width, height, new_format, flags);
-
-    if result.is_ok() {
-        if let (Some(swap_chain3), Some(pipeline)) = (swap_chain3.as_ref(), PIPELINE.get()) {
-            if let Some(mut pipeline) = pipeline.try_lock() {
-                if let Err(e) =
-                    update_pipeline_display_size_from_swap_chain(&mut pipeline, swap_chain3)
-                {
-                    warn!("Could not update DX12 display size after ResizeBuffers: {e:?}");
-                }
-            } else {
-                warn!("Could not lock DX12 pipeline to update display size after ResizeBuffers");
-            }
-        }
+    if result.is_err() {
+        return result;
     }
+
+    let Some(swap_chain3) = swap_chain3.as_ref() else {
+        return result;
+    };
+    update_display_size_after_swap_chain_change(swap_chain3, "ResizeBuffers");
 
     result
 }
@@ -769,31 +789,18 @@ unsafe extern "system" fn dxgi_swap_chain_set_source_size_impl(
     let Trampolines { dxgi_swap_chain_set_source_size, .. } =
         TRAMPOLINES.get().expect("DirectX 12 trampolines uninitialized");
 
-    if let Err(e) = wait_for_pipeline_idle() {
-        util::print_dxgi_debug_messages();
-        error!("Could not wait for DX12 pipeline to become idle before SetSourceSize: {e:?}");
-    }
+    wait_for_pipeline_idle_before("SetSourceSize");
 
     trace!("Call IDXGISwapChain2::SetSourceSize trampoline");
     let result = dxgi_swap_chain_set_source_size(swap_chain.clone(), width, height);
-
-    if result.is_ok() {
-        if let Ok(swap_chain3) = swap_chain.cast::<IDXGISwapChain3>() {
-            if let Some(pipeline) = PIPELINE.get() {
-                if let Some(mut pipeline) = pipeline.try_lock() {
-                    if let Err(e) =
-                        update_pipeline_display_size_from_swap_chain(&mut pipeline, &swap_chain3)
-                    {
-                        warn!("Could not update DX12 display size after SetSourceSize: {e:?}");
-                    }
-                } else {
-                    warn!(
-                        "Could not lock DX12 pipeline to update display size after SetSourceSize"
-                    );
-                }
-            }
-        }
+    if result.is_err() {
+        return result;
     }
+
+    let Ok(swap_chain3) = swap_chain.cast::<IDXGISwapChain3>() else {
+        return result;
+    };
+    update_display_size_after_swap_chain_change(&swap_chain3, "SetSourceSize");
 
     result
 }
@@ -812,10 +819,7 @@ unsafe extern "system" fn dxgi_swap_chain_resize_buffers1_impl(
     let Trampolines { dxgi_swap_chain_resize_buffers1, .. } =
         TRAMPOLINES.get().expect("DirectX 12 trampolines uninitialized");
 
-    if let Err(e) = wait_for_pipeline_idle() {
-        util::print_dxgi_debug_messages();
-        error!("Could not wait for DX12 pipeline to become idle before ResizeBuffers1: {e:?}");
-    }
+    wait_for_pipeline_idle_before("ResizeBuffers1");
 
     let swap_chain = p_this.clone();
     let present_queue_count = if present_queue.is_null() {
@@ -846,32 +850,21 @@ unsafe extern "system" fn dxgi_swap_chain_resize_buffers1_impl(
         present_queue,
     );
 
-    if result.is_ok() {
-        match command_queue {
-            PresentQueueCapture::Valid(command_queue) => {
-                reset_pipeline("ResizeBuffers1 present queue update");
-                complete_initialization_from_queue(&swap_chain, &command_queue);
-            },
-            PresentQueueCapture::Invalid => {
-                reset_pipeline("ResizeBuffers1 unsupported present queue configuration");
-            },
-            PresentQueueCapture::Missing => {
-                if let Some(pipeline) = PIPELINE.get() {
-                    if let Some(mut pipeline) = pipeline.try_lock() {
-                        if let Err(e) =
-                            update_pipeline_display_size_from_swap_chain(&mut pipeline, &swap_chain)
-                        {
-                            warn!("Could not update DX12 display size after ResizeBuffers1: {e:?}");
-                        }
-                    } else {
-                        warn!(
-                            "Could not lock DX12 pipeline to update display size after \
-                             ResizeBuffers1"
-                        );
-                    }
-                }
-            },
-        }
+    if result.is_err() {
+        return result;
+    }
+
+    match command_queue {
+        PresentQueueCapture::Valid(command_queue) => {
+            reset_pipeline("ResizeBuffers1 present queue update");
+            complete_initialization_from_queue(&swap_chain, &command_queue);
+        },
+        PresentQueueCapture::Invalid => {
+            reset_pipeline("ResizeBuffers1 unsupported present queue configuration");
+        },
+        PresentQueueCapture::Missing => {
+            update_display_size_after_swap_chain_change(&swap_chain, "ResizeBuffers1");
+        },
     }
 
     result

--- a/src/renderer/backend/dx12.rs
+++ b/src/renderer/backend/dx12.rs
@@ -30,7 +30,7 @@ const COMMAND_ALLOCATOR_NAMES: [&str; NUM_FRAMES] =
     ["hudhook Frame Allocator 0", "hudhook Frame Allocator 1", "hudhook Frame Allocator 2"];
 
 impl FrameContext {
-    fn new(device: &ID3D12Device, name: &str) -> Result<Self> {
+    fn new(device: &ID3D12Device, name: &str, node_mask: u32) -> Result<Self> {
         let command_allocator: ID3D12CommandAllocator =
             unsafe { device.CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT) }?;
         unsafe {
@@ -39,8 +39,8 @@ impl FrameContext {
         Ok(FrameContext {
             command_allocator,
             fence_value: 0,
-            vertex_buffer: Buffer::new(device, 5000)?,
-            index_buffer: Buffer::new(device, 10000)?,
+            vertex_buffer: Buffer::new(device, 5000, node_mask)?,
+            index_buffer: Buffer::new(device, 10000, node_mask)?,
         })
     }
 }
@@ -54,12 +54,14 @@ pub struct D3D12RenderEngine {
     #[allow(unused)]
     rtv_heap: ID3D12DescriptorHeap,
     rtv_heap_start: D3D12_CPU_DESCRIPTOR_HANDLE,
+    rtv_format: DXGI_FORMAT,
     texture_heap: TextureHeap,
 
     root_signature: ID3D12RootSignature,
     pipeline_state: ID3D12PipelineState,
 
     projection_buffer: [[f32; 4]; 4],
+    node_mask: u32,
 
     fence: Fence,
     frame_contexts: Vec<FrameContext>,
@@ -67,18 +69,54 @@ pub struct D3D12RenderEngine {
 }
 
 impl D3D12RenderEngine {
-    pub fn new(command_queue: &ID3D12CommandQueue, ctx: &mut Context) -> Result<Self> {
+    pub fn rtv_format_for_swap_chain(format: DXGI_FORMAT) -> Option<DXGI_FORMAT> {
+        match format {
+            DXGI_FORMAT_UNKNOWN
+            | DXGI_FORMAT_R32G32B32A32_TYPELESS
+            | DXGI_FORMAT_R32G32B32_TYPELESS
+            | DXGI_FORMAT_R16G16B16A16_TYPELESS
+            | DXGI_FORMAT_R32G32_TYPELESS
+            | DXGI_FORMAT_R32G8X24_TYPELESS
+            | DXGI_FORMAT_R10G10B10A2_TYPELESS
+            | DXGI_FORMAT_R8G8B8A8_TYPELESS
+            | DXGI_FORMAT_R16G16_TYPELESS
+            | DXGI_FORMAT_R32_TYPELESS
+            | DXGI_FORMAT_R24G8_TYPELESS
+            | DXGI_FORMAT_R8G8_TYPELESS
+            | DXGI_FORMAT_R16_TYPELESS
+            | DXGI_FORMAT_R8_TYPELESS
+            | DXGI_FORMAT_BC1_TYPELESS
+            | DXGI_FORMAT_BC2_TYPELESS
+            | DXGI_FORMAT_BC3_TYPELESS
+            | DXGI_FORMAT_BC4_TYPELESS
+            | DXGI_FORMAT_BC5_TYPELESS
+            | DXGI_FORMAT_B8G8R8A8_TYPELESS
+            | DXGI_FORMAT_B8G8R8X8_TYPELESS
+            | DXGI_FORMAT_BC6H_TYPELESS
+            | DXGI_FORMAT_BC7_TYPELESS => None,
+            DXGI_FORMAT_R8G8B8A8_UNORM_SRGB => Some(DXGI_FORMAT_R8G8B8A8_UNORM),
+            DXGI_FORMAT_B8G8R8A8_UNORM_SRGB => Some(DXGI_FORMAT_B8G8R8A8_UNORM),
+            _ => Some(format),
+        }
+    }
+
+    pub fn new(
+        command_queue: &ID3D12CommandQueue,
+        ctx: &mut Context,
+        rtv_format: DXGI_FORMAT,
+    ) -> Result<Self> {
         let device: ID3D12Device = util::try_out_ptr(|v| unsafe { command_queue.GetDevice(v) })?;
+        let node_mask = unsafe { command_queue.GetDesc() }.NodeMask;
         let command_queue = command_queue.clone();
 
         let mut frame_contexts = Vec::with_capacity(NUM_FRAMES);
         for name in &COMMAND_ALLOCATOR_NAMES {
-            frame_contexts.push(FrameContext::new(&device, name)?);
+            frame_contexts.push(FrameContext::new(&device, name, node_mask)?);
         }
 
         let command_list: ID3D12GraphicsCommandList = unsafe {
             device.CreateCommandList(
-                0,
+                node_mask,
                 D3D12_COMMAND_LIST_TYPE_DIRECT,
                 &frame_contexts[0].command_allocator,
                 None,
@@ -89,10 +127,11 @@ impl D3D12RenderEngine {
             command_list.SetName(w!("hudhook Render Engine Command List"))?;
         }
 
-        let (rtv_heap, texture_heap) = unsafe { create_heaps(&device) }?;
+        let (rtv_heap, texture_heap) = unsafe { create_heaps(&device, node_mask) }?;
         let rtv_heap_start = unsafe { rtv_heap.GetCPUDescriptorHandleForHeapStart() };
 
-        let (root_signature, pipeline_state) = unsafe { create_shader_program(&device) }?;
+        let (root_signature, pipeline_state) =
+            unsafe { create_shader_program(&device, rtv_format, node_mask) }?;
 
         let fence = Fence::new(&device)?;
 
@@ -106,10 +145,12 @@ impl D3D12RenderEngine {
             command_list,
             rtv_heap,
             rtv_heap_start,
+            rtv_format,
             texture_heap,
             root_signature,
             pipeline_state,
             projection_buffer: Default::default(),
+            node_mask,
             fence,
             frame_contexts,
             frame_index: 0,
@@ -151,7 +192,15 @@ impl RenderEngine for D3D12RenderEngine {
             fc.command_allocator.Reset()?;
             self.command_list.Reset(&fc.command_allocator, None)?;
 
-            self.device.CreateRenderTargetView(&render_target, None, self.rtv_heap_start);
+            self.device.CreateRenderTargetView(
+                &render_target,
+                Some(&D3D12_RENDER_TARGET_VIEW_DESC {
+                    Format: self.rtv_format,
+                    ViewDimension: D3D12_RTV_DIMENSION_TEXTURE2D,
+                    ..Default::default()
+                }),
+                self.rtv_heap_start,
+            );
 
             let present_to_rtv_barriers = [util::create_barrier(
                 &render_target,
@@ -195,6 +244,17 @@ impl RenderEngine for D3D12RenderEngine {
             self.load_texture(fonts_texture.data, fonts_texture.width, fonts_texture.height)?;
         Ok(())
     }
+
+    fn wait_idle(&mut self) -> Result<()> {
+        for fc in &mut self.frame_contexts {
+            if fc.fence_value != 0 {
+                self.fence.wait_for_value(fc.fence_value)?;
+                fc.fence_value = 0;
+            }
+        }
+
+        Ok(())
+    }
 }
 
 impl Drop for D3D12RenderEngine {
@@ -228,8 +288,8 @@ impl D3D12RenderEngine {
                 fc.index_buffer.extend(indices);
             });
 
-        fc.vertex_buffer.upload(&self.device)?;
-        fc.index_buffer.upload(&self.device)?;
+        fc.vertex_buffer.upload(&self.device, self.node_mask)?;
+        fc.index_buffer.upload(&self.device, self.node_mask)?;
 
         self.projection_buffer = {
             let [l, t, r, b] = [
@@ -338,13 +398,16 @@ impl D3D12RenderEngine {
     }
 }
 
-unsafe fn create_heaps(device: &ID3D12Device) -> Result<(ID3D12DescriptorHeap, TextureHeap)> {
+unsafe fn create_heaps(
+    device: &ID3D12Device,
+    node_mask: u32,
+) -> Result<(ID3D12DescriptorHeap, TextureHeap)> {
     let rtv_heap: ID3D12DescriptorHeap =
         device.CreateDescriptorHeap(&D3D12_DESCRIPTOR_HEAP_DESC {
             Type: D3D12_DESCRIPTOR_HEAP_TYPE_RTV,
             NumDescriptors: 1,
             Flags: D3D12_DESCRIPTOR_HEAP_FLAG_NONE,
-            NodeMask: 1,
+            NodeMask: node_mask,
         })?;
 
     let srv_heap: ID3D12DescriptorHeap =
@@ -352,16 +415,18 @@ unsafe fn create_heaps(device: &ID3D12Device) -> Result<(ID3D12DescriptorHeap, T
             Type: D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV,
             NumDescriptors: 8,
             Flags: D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE,
-            NodeMask: 0,
+            NodeMask: node_mask,
         })?;
 
-    let texture_heap = TextureHeap::new(device, srv_heap)?;
+    let texture_heap = TextureHeap::new(device, srv_heap, node_mask)?;
 
     Ok((rtv_heap, texture_heap))
 }
 
 unsafe fn create_shader_program(
     device: &ID3D12Device,
+    rtv_format: DXGI_FORMAT,
+    node_mask: u32,
 ) -> Result<(ID3D12RootSignature, ID3D12PipelineState)> {
     let parameters = [
         D3D12_ROOT_PARAMETER {
@@ -430,7 +495,7 @@ unsafe fn create_shader_program(
     .expect("D3D12SerializeRootSignature");
 
     let root_signature: ID3D12RootSignature = device.CreateRootSignature(
-        0,
+        node_mask,
         slice::from_raw_parts(blob.GetBufferPointer() as *const u8, blob.GetBufferSize()),
     )?;
 
@@ -542,14 +607,14 @@ unsafe fn create_shader_program(
 
     let pso_desc = D3D12_GRAPHICS_PIPELINE_STATE_DESC {
         pRootSignature: ManuallyDrop::new(Some(root_signature.clone())),
-        NodeMask: 1,
+        NodeMask: node_mask,
         PrimitiveTopologyType: D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE,
         SampleMask: u32::MAX,
         NumRenderTargets: 1,
         SampleDesc: DXGI_SAMPLE_DESC { Count: 1, Quality: 0 },
         Flags: D3D12_PIPELINE_STATE_FLAG_NONE,
         RTVFormats: [
-            DXGI_FORMAT_B8G8R8A8_UNORM,
+            rtv_format,
             Default::default(),
             Default::default(),
             Default::default(),
@@ -625,22 +690,26 @@ struct Buffer<T: Sized> {
 }
 
 impl<T> Buffer<T> {
-    fn new(device: &ID3D12Device, resource_capacity: usize) -> Result<Self> {
-        let resource = Self::create_resource(device, resource_capacity)?;
+    fn new(device: &ID3D12Device, resource_capacity: usize, node_mask: u32) -> Result<Self> {
+        let resource = Self::create_resource(device, resource_capacity, node_mask)?;
         let data = Vec::with_capacity(resource_capacity);
 
         Ok(Self { resource, resource_capacity, data })
     }
 
-    fn create_resource(device: &ID3D12Device, resource_capacity: usize) -> Result<ID3D12Resource> {
+    fn create_resource(
+        device: &ID3D12Device,
+        resource_capacity: usize,
+        node_mask: u32,
+    ) -> Result<ID3D12Resource> {
         util::try_out_ptr(|v| unsafe {
             device.CreateCommittedResource(
                 &D3D12_HEAP_PROPERTIES {
                     Type: D3D12_HEAP_TYPE_UPLOAD,
                     CPUPageProperty: D3D12_CPU_PAGE_PROPERTY_UNKNOWN,
                     MemoryPoolPreference: D3D12_MEMORY_POOL_UNKNOWN,
-                    CreationNodeMask: 0,
-                    VisibleNodeMask: 0,
+                    CreationNodeMask: node_mask,
+                    VisibleNodeMask: node_mask,
                 },
                 D3D12_HEAP_FLAG_NONE,
                 &D3D12_RESOURCE_DESC {
@@ -670,10 +739,13 @@ impl<T> Buffer<T> {
         self.data.extend(it)
     }
 
-    fn upload(&mut self, device: &ID3D12Device) -> Result<()> {
+    fn upload(&mut self, device: &ID3D12Device, node_mask: u32) -> Result<()> {
         let capacity = self.data.capacity();
         if capacity > self.resource_capacity {
-            drop(mem::replace(&mut self.resource, Self::create_resource(device, capacity)?));
+            drop(mem::replace(
+                &mut self.resource,
+                Self::create_resource(device, capacity, node_mask)?,
+            ));
             self.resource_capacity = capacity;
         }
 
@@ -706,16 +778,17 @@ struct TextureHeap {
     command_allocator: ID3D12CommandAllocator,
     command_list: ID3D12GraphicsCommandList,
     fence: Fence,
+    node_mask: u32,
 }
 
 impl TextureHeap {
-    fn new(device: &ID3D12Device, srv_heap: ID3D12DescriptorHeap) -> Result<Self> {
+    fn new(device: &ID3D12Device, srv_heap: ID3D12DescriptorHeap, node_mask: u32) -> Result<Self> {
         let command_queue = unsafe {
             device.CreateCommandQueue(&D3D12_COMMAND_QUEUE_DESC {
                 Type: D3D12_COMMAND_LIST_TYPE_DIRECT,
                 Priority: 0,
                 Flags: D3D12_COMMAND_QUEUE_FLAG_NONE,
-                NodeMask: 0,
+                NodeMask: node_mask,
             })
         }?;
 
@@ -723,7 +796,12 @@ impl TextureHeap {
             unsafe { device.CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT) }?;
 
         let command_list: ID3D12GraphicsCommandList = unsafe {
-            device.CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, &command_allocator, None)
+            device.CreateCommandList(
+                node_mask,
+                D3D12_COMMAND_LIST_TYPE_DIRECT,
+                &command_allocator,
+                None,
+            )
         }?;
 
         unsafe {
@@ -737,7 +815,7 @@ impl TextureHeap {
                 Type: D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV,
                 NumDescriptors: 8,
                 Flags: D3D12_DESCRIPTOR_HEAP_FLAG_NONE,
-                NodeMask: 0,
+                NodeMask: node_mask,
             })
         }?;
 
@@ -752,6 +830,7 @@ impl TextureHeap {
             command_allocator,
             command_list,
             fence,
+            node_mask,
         })
     }
 
@@ -827,8 +906,8 @@ impl TextureHeap {
                     Type: D3D12_HEAP_TYPE_DEFAULT,
                     CPUPageProperty: D3D12_CPU_PAGE_PROPERTY_UNKNOWN,
                     MemoryPoolPreference: D3D12_MEMORY_POOL_UNKNOWN,
-                    CreationNodeMask: Default::default(),
-                    VisibleNodeMask: Default::default(),
+                    CreationNodeMask: self.node_mask,
+                    VisibleNodeMask: self.node_mask,
                 },
                 D3D12_HEAP_FLAG_NONE,
                 &D3D12_RESOURCE_DESC {
@@ -907,8 +986,8 @@ impl TextureHeap {
                     Type: D3D12_HEAP_TYPE_UPLOAD,
                     CPUPageProperty: D3D12_CPU_PAGE_PROPERTY_UNKNOWN,
                     MemoryPoolPreference: D3D12_MEMORY_POOL_UNKNOWN,
-                    CreationNodeMask: Default::default(),
-                    VisibleNodeMask: Default::default(),
+                    CreationNodeMask: self.node_mask,
+                    VisibleNodeMask: self.node_mask,
                 },
                 D3D12_HEAP_FLAG_NONE,
                 &D3D12_RESOURCE_DESC {
@@ -978,9 +1057,9 @@ impl TextureHeap {
         self.command_list.ResourceBarrier(&barriers);
         self.command_list.Close()?;
         self.command_queue.ExecuteCommandLists(&[Some(self.command_list.cast()?)]);
-        self.command_queue.Signal(self.fence.fence(), self.fence.value())?;
-        self.fence.wait()?;
-        self.fence.incr();
+        let fence_value = self.fence.incr() + 1;
+        self.command_queue.Signal(self.fence.fence(), fence_value)?;
+        self.fence.wait_for_value(fence_value)?;
 
         barriers.into_iter().for_each(util::drop_barrier);
 
@@ -992,5 +1071,55 @@ impl TextureHeap {
         let _ = ManuallyDrop::into_inner(dst_location.pResource);
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rtv_format_for_swap_chain_accepts_typed_render_target_formats() {
+        assert_eq!(
+            D3D12RenderEngine::rtv_format_for_swap_chain(DXGI_FORMAT_R8G8B8A8_UNORM),
+            Some(DXGI_FORMAT_R8G8B8A8_UNORM)
+        );
+        assert_eq!(
+            D3D12RenderEngine::rtv_format_for_swap_chain(DXGI_FORMAT_B8G8R8A8_UNORM),
+            Some(DXGI_FORMAT_B8G8R8A8_UNORM)
+        );
+        assert_eq!(
+            D3D12RenderEngine::rtv_format_for_swap_chain(DXGI_FORMAT_R10G10B10A2_UNORM),
+            Some(DXGI_FORMAT_R10G10B10A2_UNORM)
+        );
+        assert_eq!(
+            D3D12RenderEngine::rtv_format_for_swap_chain(DXGI_FORMAT_R16G16B16A16_FLOAT),
+            Some(DXGI_FORMAT_R16G16B16A16_FLOAT)
+        );
+    }
+
+    #[test]
+    fn rtv_format_for_swap_chain_normalizes_srgb_formats() {
+        assert_eq!(
+            D3D12RenderEngine::rtv_format_for_swap_chain(DXGI_FORMAT_R8G8B8A8_UNORM_SRGB),
+            Some(DXGI_FORMAT_R8G8B8A8_UNORM)
+        );
+        assert_eq!(
+            D3D12RenderEngine::rtv_format_for_swap_chain(DXGI_FORMAT_B8G8R8A8_UNORM_SRGB),
+            Some(DXGI_FORMAT_B8G8R8A8_UNORM)
+        );
+    }
+
+    #[test]
+    fn rtv_format_for_swap_chain_rejects_unknown_and_typeless_formats() {
+        assert_eq!(D3D12RenderEngine::rtv_format_for_swap_chain(DXGI_FORMAT_UNKNOWN), None);
+        assert_eq!(
+            D3D12RenderEngine::rtv_format_for_swap_chain(DXGI_FORMAT_R8G8B8A8_TYPELESS),
+            None
+        );
+        assert_eq!(
+            D3D12RenderEngine::rtv_format_for_swap_chain(DXGI_FORMAT_R10G10B10A2_TYPELESS),
+            None
+        );
     }
 }

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -15,6 +15,10 @@ pub(crate) trait RenderEngine: RenderContext {
 
     fn render(&mut self, draw_data: &DrawData, render_target: Self::RenderTarget) -> Result<()>;
     fn setup_fonts(&mut self, ctx: &mut Context) -> Result<()>;
+
+    fn wait_idle(&mut self) -> Result<()> {
+        Ok(())
+    }
 }
 #[cfg(feature = "dx11")]
 pub(crate) use backend::dx11::D3D11RenderEngine;

--- a/src/renderer/pipeline.rs
+++ b/src/renderer/pipeline.rs
@@ -191,6 +191,10 @@ impl<T: RenderEngine> Pipeline<T> {
         }
     }
 
+    pub(crate) fn wait_idle(&mut self) -> Result<()> {
+        self.engine.wait_idle()
+    }
+
     pub(crate) fn cleanup(&mut self) {
         unsafe {
             SetWindowLongPtrW(self.hwnd, GWLP_WNDPROC, self.shared_state.wnd_proc as usize as _)

--- a/tests/harness/dx12.rs
+++ b/tests/harness/dx12.rs
@@ -95,10 +95,7 @@ unsafe fn run_harness(done: Arc<AtomicBool>, rx: Receiver<SendMsg>) -> Result<()
         None,
     )?;
 
-    trace!("Enabling debug");
-    util::enable_debug_interface();
-
-    let factory: IDXGIFactory2 = CreateDXGIFactory2(DXGI_CREATE_FACTORY_DEBUG)?;
+    let factory: IDXGIFactory2 = CreateDXGIFactory2(DXGI_CREATE_FACTORY_FLAGS(0))?;
     let adapter = factory.EnumAdapters(0)?;
 
     let device: ID3D12Device =
@@ -124,6 +121,7 @@ unsafe fn run_harness(done: Arc<AtomicBool>, rx: Receiver<SendMsg>) -> Result<()
     command_allocator.SetName(w!("Harness Command Allocator"))?;
     command_list.SetName(w!("Harness Command List"))?;
 
+    let swap_chain_format = DXGI_FORMAT_B8G8R8A8_UNORM;
     let swap_chain: IDXGISwapChain3 = factory
         .CreateSwapChainForHwnd(
             &command_queue,
@@ -136,7 +134,7 @@ unsafe fn run_harness(done: Arc<AtomicBool>, rx: Receiver<SendMsg>) -> Result<()
                 Flags: 0,
                 Width: 800,
                 Height: 600,
-                Format: DXGI_FORMAT_B8G8R8A8_UNORM,
+                Format: swap_chain_format,
                 Stereo: false.into(),
                 Scaling: DXGI_SCALING_NONE,
                 AlphaMode: DXGI_ALPHA_MODE_IGNORE,
@@ -163,26 +161,18 @@ unsafe fn run_harness(done: Arc<AtomicBool>, rx: Receiver<SendMsg>) -> Result<()
             + device.GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV) as usize,
     };
 
-    {
-        let buf: ID3D12Resource = swap_chain.GetBuffer(0).unwrap();
-        buf.SetName(w!("Harness back buffer 0"))?;
-        device.CreateRenderTargetView(&buf, None, rtv_desc0);
-        drop(buf);
-        let buf: ID3D12Resource = swap_chain.GetBuffer(1).unwrap();
-        buf.SetName(w!("Harness back buffer 1"))?;
-        device.CreateRenderTargetView(&buf, None, rtv_desc1);
-        drop(buf);
-    }
-
     let rtv = [rtv_desc0, rtv_desc1];
+    recreate_render_targets(&device, &swap_chain, &rtv)?;
 
     let fence: ID3D12Fence = device.CreateFence(0, D3D12_FENCE_FLAG_NONE)?;
     let mut fence_val = 0u64;
     let fence_event = CreateEventExW(None, None, CREATE_EVENT(0), 0x1F0003)?;
+    let mut frame_count = 0u32;
+    let mut resized_once = false;
 
     loop {
         util::print_dxgi_debug_messages();
-        let rtv = rtv[swap_chain.GetCurrentBackBufferIndex() as usize];
+        let current_rtv = rtv[swap_chain.GetCurrentBackBufferIndex() as usize];
         let back_buffer = swap_chain.GetBuffer(swap_chain.GetCurrentBackBufferIndex())?;
 
         let rtv_barrier = [util::create_barrier(
@@ -202,7 +192,7 @@ unsafe fn run_harness(done: Arc<AtomicBool>, rx: Receiver<SendMsg>) -> Result<()
         command_allocator.Reset()?;
         command_list.Reset(&command_allocator, None)?;
         command_list.ResourceBarrier(&rtv_barrier);
-        command_list.ClearRenderTargetView(rtv, &[0.3, 0.8, 0.3, 0.8], None);
+        command_list.ClearRenderTargetView(current_rtv, &[0.3, 0.8, 0.3, 0.8], None);
         command_list.ResourceBarrier(&present_barrier);
         command_list.Close()?;
         command_queue.ExecuteCommandLists(&[Some(command_list.cast()?)]);
@@ -218,6 +208,14 @@ unsafe fn run_harness(done: Arc<AtomicBool>, rx: Receiver<SendMsg>) -> Result<()
         present_barrier.into_iter().for_each(util::drop_barrier);
 
         swap_chain.Present(0, DXGI_PRESENT(0)).ok()?;
+
+        frame_count += 1;
+        if !resized_once && frame_count >= 60 {
+            trace!("Programmatic ResizeBuffers 1024x768");
+            swap_chain.ResizeBuffers(2, 1024, 768, swap_chain_format, DXGI_SWAP_CHAIN_FLAG(0))?;
+            recreate_render_targets(&device, &swap_chain, &rtv)?;
+            resized_once = true;
+        }
 
         let mut msg = MSG::default();
         if PeekMessageA(&mut msg, Some(hwnd), 0, 0, PM_REMOVE).as_bool() {
@@ -238,19 +236,17 @@ unsafe fn run_harness(done: Arc<AtomicBool>, rx: Receiver<SendMsg>) -> Result<()
                     let height = hiword(lparam.0 as u32) as u32;
                     trace!("Resizing {width}x{height}");
 
-                    // TODO look deeper into this crash.
-                    // swap_chain.ResizeBuffers(2, width, height, DXGI_FORMAT_B8G8R8A8_UNORM, 0)?;
+                    if width > 0 && height > 0 {
+                        swap_chain.ResizeBuffers(
+                            2,
+                            width,
+                            height,
+                            swap_chain_format,
+                            DXGI_SWAP_CHAIN_FLAG(0),
+                        )?;
+                        recreate_render_targets(&device, &swap_chain, &rtv)?;
+                    }
                     trace!("Resized");
-
-                    let buf: ID3D12Resource = swap_chain.GetBuffer(0).unwrap();
-                    buf.SetName(w!("Harness back buffer 0"))?;
-                    device.CreateRenderTargetView(&buf, None, rtv_desc0);
-                    drop(buf);
-
-                    let buf: ID3D12Resource = swap_chain.GetBuffer(1).unwrap();
-                    buf.SetName(w!("Harness back buffer 1"))?;
-                    device.CreateRenderTargetView(&buf, None, rtv_desc1);
-                    drop(buf);
                 },
                 _ => {},
             }
@@ -259,6 +255,24 @@ unsafe fn run_harness(done: Arc<AtomicBool>, rx: Receiver<SendMsg>) -> Result<()
         if done.load(Ordering::SeqCst) {
             break;
         }
+    }
+
+    Ok(())
+}
+
+unsafe fn recreate_render_targets(
+    device: &ID3D12Device,
+    swap_chain: &IDXGISwapChain3,
+    rtv: &[D3D12_CPU_DESCRIPTOR_HANDLE; 2],
+) -> Result<()> {
+    for (idx, rtv) in rtv.iter().enumerate() {
+        let buf: ID3D12Resource = swap_chain.GetBuffer(idx as u32)?;
+        if idx == 0 {
+            buf.SetName(w!("Harness back buffer 0"))?;
+        } else {
+            buf.SetName(w!("Harness back buffer 1"))?;
+        }
+        device.CreateRenderTargetView(&buf, None, *rtv);
     }
 
     Ok(())


### PR DESCRIPTION
* Capture DX12 command queues from swap-chain creation and ResizeBuffers1 paths, validate active swap-chain/device/queue identity, and rebuild the overlay pipeline safely after resize, format, buffer-count, or device changes.
* Thread RTV format and NodeMask through the DX12 renderer, wait for overlay fences before resize, fix texture upload fence ordering, and extend the DX12 harness to exercise real ResizeBuffers.

This PR should also fix the issue noted in #257.

It is ported from recent changes for my EROverlay project which are inspired by RadialMenu to support MSHybrid GPU switching mechanism and resizing of rendering context.